### PR TITLE
Add tests for generated code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,12 +60,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
@@ -87,6 +106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "macro-utils"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -188,6 +216,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2077e54d38055cf1ca0fd7933a2e00cd3ec8f6fed352b2a377f06dcdaaf3281"
+dependencies = [
+ "kernel32-sys",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "text-diff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "309238dd66f8bf11a20d015b727b926f294a13fcb8d56770bb984e7a22c43897"
+dependencies = [
+ "getopts",
+ "term",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,14 +252,26 @@ checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 dependencies = [
  "libc",
  "redox_syscall",
- "winapi",
+ "winapi 0.3.8",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
@@ -222,6 +282,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -252,7 +318,16 @@ name = "xsd-parser"
 version = "0.1.0"
 dependencies = [
  "Inflector",
+ "itertools",
+ "log",
+ "macro-utils",
  "roxmltree",
+ "syn",
+ "text-diff",
+ "xml-rs",
+ "xsd-types",
+ "yaserde",
+ "yaserde_derive",
 ]
 
 [[package]]

--- a/macro-utils/Cargo.toml
+++ b/macro-utils/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xsd-parser"
+name = "macro-utils"
 version = "0.1.0"
 authors = ["Chris Bruce <chris@lumeo.com>", "leonid.krutovsky <leonid.krutovsky@quantumsoft.ru>", "DmitrySamoylov <dmitry.samoylov@quantumsoft.ru>", "victor-soloviev <victor.soloviev@quantumsoft.ru>"]
 edition = "2018"
@@ -7,16 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-roxmltree = "0.7.3"
-Inflector = "*"
+syn = "~1.0"
+proc-macro2 = "~1.0"
+quote = "~1.0"
 
-[dev-dependencies]
-syn = { version = "1.0", features = ["full"] }
-log = "0.4.8"
-xml-rs = "0.8.0"
-yaserde = "0.3.13"
-yaserde_derive = "0.3.13"
-text-diff = "0.4.0"
-itertools = "0.8.1"
-macro-utils = { path = "../macro-utils" }
-xsd-types = { path = "../xsd-types" }
+[lib]
+name = "macro_utils"
+proc-macro = true

--- a/macro-utils/src/lib.rs
+++ b/macro-utils/src/lib.rs
@@ -1,0 +1,24 @@
+extern crate proc_macro;
+extern crate proc_macro2;
+#[macro_use]
+extern crate quote;
+extern crate syn;
+
+mod tuple;
+
+#[proc_macro_derive(UtilsTupleSerDe)]
+pub fn tuple_serde(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = syn::parse(input).unwrap();
+
+    let from_str = tuple::from_str(&ast);
+    let display = tuple::display(&ast);
+    let serde = tuple::serde(&ast);
+
+    let ts = quote! {
+        #from_str
+        #display
+        #serde
+    };
+
+    ts.into()
+}

--- a/macro-utils/src/tuple.rs
+++ b/macro-utils/src/tuple.rs
@@ -1,0 +1,146 @@
+use proc_macro2::TokenStream;
+use quote;
+use syn::spanned::Spanned;
+
+enum Type<'a> {
+    Simple(&'a syn::Path),
+    String(&'a syn::Path),
+    Struct(&'a syn::Path),
+    Vec(&'a syn::Path, &'a syn::Path),
+}
+
+pub fn from_str(ast: &syn::DeriveInput) -> TokenStream {
+    let convert = match extract_field_type(ast) {
+        Type::String(_) => quote! { s.to_string() },
+        Type::Struct(ty) => quote! { #ty::from_str(s)? },
+        Type::Simple(ty) => quote! { #ty::from_str(s).map_err(|e| e.to_string())? },
+        Type::Vec(_, subtype) => match Type::from_path(&subtype) {
+            Type::String(subtype) | Type::Struct(subtype) | Type::Simple(subtype) => quote! {
+                s.split_whitespace()
+                    .filter_map(|s| #subtype::from_str(s).ok())
+                    .collect()
+            },
+            _ => syn::Error::new(subtype.span(), "Not implemented for this subtype")
+                .to_compile_error(),
+        },
+    };
+
+    let struct_name = &ast.ident;
+
+    quote! {
+        impl std::str::FromStr for #struct_name {
+            type Err = String;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                use std::str::FromStr;
+
+                Ok(#struct_name(#convert))
+            }
+        }
+    }
+}
+
+pub fn display(ast: &syn::DeriveInput) -> TokenStream {
+    let write = match extract_field_type(ast) {
+        Type::String(_) | Type::Simple(_) | Type::Struct(_) => quote! {
+            write!(f, "{}", self.0)
+        },
+        Type::Vec(_, subtype) => match Type::from_path(&subtype) {
+            Type::String(_) | Type::Simple(_) | Type::Struct(_) => quote! {
+                write!(f, "{}", self.0.iter().join(" "))
+            },
+            _ => syn::Error::new(subtype.span(), "Not implemented for this subtype")
+                .to_compile_error(),
+        },
+    };
+
+    let struct_name = &ast.ident;
+
+    quote! {
+        impl std::fmt::Display for #struct_name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                use itertools::Itertools;
+                #write
+            }
+        }
+    }
+}
+
+impl Type<'_> {
+    pub fn from_path(path: &syn::Path) -> Type {
+        match path
+            .segments
+            .last()
+            .expect("Empty type")
+            .ident
+            .to_string()
+            .as_str()
+        {
+            "bool" | "i8" | "u8" | "i16" | "u16" | "i32" | "u32" | "i64" | "u64" | "f32"
+            | "f64" => Type::Simple(path),
+            "String" => Type::String(path),
+            "Vec" => Type::Vec(
+                path,
+                extract_subtype(path.segments.last().expect("Missing subtype"))
+                    .expect("Vec subtype not found"),
+            ),
+            _ => Type::Struct(path),
+        }
+    }
+}
+
+pub fn serde(ast: &syn::DeriveInput) -> TokenStream {
+    let struct_name = &ast.ident;
+    let struct_name_literal = &ast.ident.to_string();
+
+    quote! {
+        impl YaSerialize for #struct_name {
+            fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
+                utils::yaserde::serialize(self, #struct_name_literal, writer, |s| s.to_string())
+            }
+        }
+
+        impl YaDeserialize for #struct_name {
+            fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
+                utils::yaserde::deserialize(reader, |s| #struct_name::from_str(s))
+            }
+        }
+    }
+}
+
+fn extract_field_type(ast: &syn::DeriveInput) -> Type {
+    match &ast.data {
+        syn::Data::Struct(data_struct) => {
+            let field_path = extract_field_path(&data_struct).expect("Bad field count or type");
+
+            Type::from_path(&field_path)
+        }
+        _ => unimplemented!("Implemented only for structs"),
+    }
+}
+
+fn extract_field_path(data_struct: &syn::DataStruct) -> Option<&syn::Path> {
+    if let syn::Fields::Unnamed(fields) = &data_struct.fields {
+        if let Some(field) = fields.unnamed.first() {
+            if let syn::Type::Path(path) = &field.ty {
+                return Some(&path.path);
+            }
+        }
+    }
+
+    None
+}
+
+fn extract_subtype(path: &syn::PathSegment) -> Option<&syn::Path> {
+    if let syn::PathArguments::AngleBracketed(args) = &path.arguments {
+        if let Some(arg) = args.args.last() {
+            if let syn::GenericArgument::Type(ty) = arg {
+                if let syn::Type::Path(path) = ty {
+                    return Some(&path.path);
+                }
+            }
+        }
+    }
+
+    None
+}

--- a/xsd-parser-rs/src/generator/default.rs
+++ b/xsd-parser-rs/src/generator/default.rs
@@ -115,7 +115,10 @@ mod test {
         assert_eq!(default_format_type("Enum", &None), "Enum");
 
         assert_eq!(default_format_type("xs:integer", &None), "xs::Integer");
-        assert_eq!(default_format_type("xs:nonNegativeInteger", &None), "xs::Integer");
+        assert_eq!(
+            default_format_type("xs:nonNegativeInteger", &None),
+            "xs::Integer"
+        );
     }
 
     #[test]

--- a/xsd-parser-rs/src/main.rs
+++ b/xsd-parser-rs/src/main.rs
@@ -1,5 +1,14 @@
+#[cfg(test)]
+#[macro_use]
+extern crate log;
+#[cfg(test)]
+#[macro_use]
+extern crate yaserde_derive;
+
 mod generator;
 mod parser;
+#[cfg(test)]
+mod tests;
 mod yaserde_generator;
 
 use std::fs;

--- a/xsd-parser-rs/src/tests/README.md
+++ b/xsd-parser-rs/src/tests/README.md
@@ -1,0 +1,78 @@
+### Structure
+
+This module contains mutliple test cases. 
+Each case is a separate module and is located in its own directory, 
+for example here are contents of directory `complex_type`:
+```
+complex_type
+├── input.xsd      # Manually-written schema containing a single case
+├── expected.rs    # What Rust code we expect after processing input.xsd
+├── example.xml    # Example XML generated using xsd2inst or written manually
+└── mod.rs         # Finer-grade tests for this case
+``` 
+
+It may look that there are too many files for each case but it is made for convenience.
+Modern IDE's support code highlight/completion for `XSD's` and other file types 
+so it is always better to have separate files instead of raw strings.
+
+### What is checked
+
+For each test case we check that:
+- code generated from `input.xsd` has the same AST that we've put into `expected.rs`
+- manually written `expected.rs`
+    - compiles
+    - is correctly (de)serialized
+
+We could have check if generator output compiles at runtime (with `trybuild`) but we don't do
+that because we already check that it's AST is equivalent to `expected.rs`.
+Another reason is that `expected.rs` participates in compilation so errors are easier to locate.
+
+### What is not checked
+
+Since only AST's are compared anything not related to AST is ignored, like:
+- comments
+- formatting
+
+### How to make a new case
+
+The easiest way is: 
+- copy existing case to a new directory `new_test`
+- register `new_test` in `mod.rs`
+- modify `new_test/input.xsd` according to your case
+- generate `new_test/example.xml` with `xsd2inst` (see below for details)
+- modify `new_test/example.xml` to your taste
+- modify `new_test/expected.rs` manually or cheat:
+    - run test `cargo t tests::new_test::generator_does_not_panic -- --nocapture`
+    - copy printed struct to `expected.rs` if it looks fine
+- modify `new_test/mod.rs`:
+    - test `(de)serialization_works` most likely will be different for each case
+    - other tests are unlikely to change
+
+### xsd2inst
+
+```
+Generates a document based on the given Schema file having the given element as root.
+The tool makes reasonable attempts to create a valid document, but this is not always 
+possible since, for example, there are schemas for which no valid instance document 
+can be produced.
+```
+
+Installation:
+```bash
+sudo apt install xmlbeans
+```
+
+Usually all you need is to run this command:
+
+```bash
+xsd2inst input.xsd -name Foo > example.xml
+```
+
+Please note that you cannot just declare a type in schema root and generate XML from it. 
+You will also need to add an element in the root:
+
+```xml
+<xs:element name="Foo" type="tns:Foo"/>
+```
+
+and pass this global element name `Foo` to `xsd2inst`

--- a/xsd-parser-rs/src/tests/any/example.xml
+++ b/xsd-parser-rs/src/tests/any/example.xml
@@ -1,0 +1,5 @@
+<exam:Foo xmlns:exam="http://example.com">
+  <exam:Name>abcd</exam:Name>
+  <!--You may enter ANY elements at this point-->
+  <AnyElement/>
+</exam:Foo>

--- a/xsd-parser-rs/src/tests/any/expected.rs
+++ b/xsd-parser-rs/src/tests/any/expected.rs
@@ -1,0 +1,6 @@
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct FooType {
+    #[yaserde(prefix = "tns", rename = "Name")]
+    pub name: String,
+}

--- a/xsd-parser-rs/src/tests/any/input.xsd
+++ b/xsd-parser-rs/src/tests/any/input.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+    <xs:complexType name="FooType">
+        <xs:sequence>
+            <xs:element name="Name" type="xs:string"/>
+            <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/any/mod.rs
+++ b/xsd-parser-rs/src/tests/any/mod.rs
@@ -13,7 +13,12 @@ fn deserialization_works() {
 
     let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
 
-    assert_eq!(de, expected::FooType { min: 1, max: 2 });
+    assert_eq!(
+        de,
+        expected::FooType {
+            name: "abcd".to_string()
+        }
+    );
 }
 
 #[test]
@@ -22,6 +27,7 @@ fn generator_does_not_panic() {
 }
 
 #[test]
+#[ignore]
 fn generator_output_has_correct_ast() {
     utils::ast_test(include_str!("input.xsd"), include_str!("expected.rs"));
 }

--- a/xsd-parser-rs/src/tests/choice/example.xml
+++ b/xsd-parser-rs/src/tests/choice/example.xml
@@ -1,0 +1,3 @@
+<exam:Foo xmlns:exam="http://example.com">
+  <exam:Baz>3</exam:Baz>
+</exam:Foo>

--- a/xsd-parser-rs/src/tests/choice/expected.rs
+++ b/xsd-parser-rs/src/tests/choice/expected.rs
@@ -1,0 +1,25 @@
+#[derive(Default, PartialEq, Debug, UtilsTupleSerDe)]
+pub struct BarType(pub String);
+
+#[derive(Default, PartialEq, Debug, UtilsTupleSerDe)]
+pub struct BazType(pub i32);
+
+#[derive(PartialEq, Debug, YaSerialize, YaDeserialize)]
+pub enum FooTypeChoice {
+    Bar(BarType),
+    Baz(BazType),
+    __Unknown__(String),
+}
+
+impl Default for FooTypeChoice {
+    fn default() -> FooTypeChoice {
+        Self::__Unknown__("No valid variants".into())
+    }
+}
+
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct FooType {
+    #[yaserde(flatten)]
+    pub foo_type_choice: FooTypeChoice,
+}

--- a/xsd-parser-rs/src/tests/choice/input.xsd
+++ b/xsd-parser-rs/src/tests/choice/input.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+
+    <xs:simpleType name="BarType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="BazType">
+        <xs:restriction base="xs:int"/>
+    </xs:simpleType>
+
+    <xs:complexType name="FooType">
+        <xs:choice>
+            <xs:element name="Bar" type="tns:BarType"/>
+            <xs:element name="Baz" type="tns:BazType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/choice/mod.rs
+++ b/xsd-parser-rs/src/tests/choice/mod.rs
@@ -1,0 +1,42 @@
+use super::utils;
+
+#[test]
+fn deserialization_works() {
+    mod expected {
+        use macro_utils::*;
+        use std::io::{Read, Write};
+        use std::str::FromStr;
+        use xsd_types::utils;
+        use yaserde::{YaDeserialize, YaSerialize};
+
+        include!("expected.rs");
+    }
+
+    let ser = include_str!("example.xml");
+
+    let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
+
+    assert_eq!(
+        de,
+        expected::FooType {
+            foo_type_choice: expected::FooTypeChoice::Baz(expected::BazType(3))
+        }
+    );
+}
+
+#[test]
+fn generator_does_not_panic() {
+    let rust_code = utils::generate(include_str!("input.xsd"));
+    println!("{}", rust_code)
+}
+
+#[test]
+#[ignore] // Validation is not needed in this case
+fn generator_output_has_correct_ast() {
+    let expected = include_str!("expected.rs");
+    let actual = utils::generate(include_str!("input.xsd"));
+
+    text_diff::print_diff(expected, &actual, "\n");
+
+    utils::assert_ast_eq(expected, &actual)
+}

--- a/xsd-parser-rs/src/tests/choice/mod.rs
+++ b/xsd-parser-rs/src/tests/choice/mod.rs
@@ -26,17 +26,11 @@ fn deserialization_works() {
 
 #[test]
 fn generator_does_not_panic() {
-    let rust_code = utils::generate(include_str!("input.xsd"));
-    println!("{}", rust_code)
+    println!("{}", utils::generate(include_str!("input.xsd")))
 }
 
 #[test]
 #[ignore] // Validation is not needed in this case
 fn generator_output_has_correct_ast() {
-    let expected = include_str!("expected.rs");
-    let actual = utils::generate(include_str!("input.xsd"));
-
-    text_diff::print_diff(expected, &actual, "\n");
-
-    utils::assert_ast_eq(expected, &actual)
+    utils::ast_test(include_str!("input.xsd"), include_str!("expected.rs"));
 }

--- a/xsd-parser-rs/src/tests/complex_type/example.xml
+++ b/xsd-parser-rs/src/tests/complex_type/example.xml
@@ -1,0 +1,4 @@
+<exam:Foo xmlns:exam="http://example.com">
+  <exam:Min>1</exam:Min>
+  <exam:Max>2</exam:Max>
+</exam:Foo>

--- a/xsd-parser-rs/src/tests/complex_type/expected.rs
+++ b/xsd-parser-rs/src/tests/complex_type/expected.rs
@@ -1,0 +1,9 @@
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct FooType {
+    #[yaserde(prefix = "tns", rename = "Min")]
+    pub min: i32,
+
+    #[yaserde(prefix = "tns", rename = "Max")]
+    pub max: i32,
+}

--- a/xsd-parser-rs/src/tests/complex_type/input.xsd
+++ b/xsd-parser-rs/src/tests/complex_type/input.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+    <xs:complexType name="FooType">
+        <xs:sequence>
+            <xs:element name="Min" type="xs:int"/>
+            <xs:element name="Max" type="xs:int"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/complex_type/mod.rs
+++ b/xsd-parser-rs/src/tests/complex_type/mod.rs
@@ -1,0 +1,33 @@
+use super::utils;
+
+#[test]
+fn deserialization_works() {
+    mod expected {
+        use std::io::{Read, Write};
+        use yaserde::{YaDeserialize, YaSerialize};
+
+        include!("expected.rs");
+    }
+
+    let ser = include_str!("example.xml");
+
+    let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
+
+    assert_eq!(de, expected::FooType { min: 1, max: 2 });
+}
+
+#[test]
+fn generator_does_not_panic() {
+    let rust_code = utils::generate(include_str!("input.xsd"));
+    println!("{}", rust_code)
+}
+
+#[test]
+fn generator_output_has_correct_ast() {
+    let expected = include_str!("expected.rs");
+    let actual = utils::generate(include_str!("input.xsd"));
+
+    text_diff::print_diff(expected, &actual, "\n");
+
+    utils::assert_ast_eq(expected, &actual)
+}

--- a/xsd-parser-rs/src/tests/enumeration/example.xml
+++ b/xsd-parser-rs/src/tests/enumeration/example.xml
@@ -1,0 +1,1 @@
+<exam:Foo xmlns:exam="http://example.com">AUTO</exam:Foo>

--- a/xsd-parser-rs/src/tests/enumeration/expected.rs
+++ b/xsd-parser-rs/src/tests/enumeration/expected.rs
@@ -1,0 +1,19 @@
+#[derive(PartialEq, Debug, YaSerialize, YaDeserialize)]
+pub enum FooType {
+    #[yaserde(rename = "OFF")]
+    Off,
+
+    #[yaserde(rename = "ON")]
+    On,
+
+    #[yaserde(rename = "AUTO")]
+    Auto,
+
+    __Unknown__(String)
+}
+
+impl Default for FooType {
+    fn default() -> FooType {
+        Self::__Unknown__("No valid variants".into())
+    }
+}

--- a/xsd-parser-rs/src/tests/enumeration/input.xsd
+++ b/xsd-parser-rs/src/tests/enumeration/input.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+
+    <xs:simpleType name="FooType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="OFF"/>
+            <xs:enumeration value="ON"/>
+            <xs:enumeration value="AUTO"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/enumeration/mod.rs
+++ b/xsd-parser-rs/src/tests/enumeration/mod.rs
@@ -13,7 +13,7 @@ fn deserialization_works() {
 
     let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
 
-    assert_eq!(de, expected::FooType { min: 1, max: 2 });
+    assert_eq!(de, expected::FooType::Auto);
 }
 
 #[test]

--- a/xsd-parser-rs/src/tests/extension_base/example.xml
+++ b/xsd-parser-rs/src/tests/extension_base/example.xml
@@ -1,0 +1,5 @@
+<exam:Foo xmlns:exam="http://example.com">
+  <exam:b>3</exam:b>
+  <exam:c>string</exam:c>
+  <exam:a>1.5E2</exam:a>
+</exam:Foo>

--- a/xsd-parser-rs/src/tests/extension_base/expected.rs
+++ b/xsd-parser-rs/src/tests/extension_base/expected.rs
@@ -1,0 +1,22 @@
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct BarType {
+    #[yaserde(prefix = "tns", rename = "b")]
+    pub b: i32,
+
+    #[yaserde(prefix = "tns", rename = "c")]
+    pub c: String,
+}
+
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct FooType {
+    #[yaserde(prefix = "tns", rename = "a")]
+    pub a: f64,
+
+    #[yaserde(prefix = "tns", rename = "b")]
+    pub b: i32,
+
+    #[yaserde(prefix = "tns", rename = "c")]
+    pub c: String,
+}

--- a/xsd-parser-rs/src/tests/extension_base/input.xsd
+++ b/xsd-parser-rs/src/tests/extension_base/input.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+
+    <xs:complexType name="BarType">
+        <xs:sequence>
+            <xs:element name="b" type="xs:int"/>
+            <xs:element name="c" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="FooType">
+        <xs:complexContent>
+            <xs:extension base="tns:BarType">
+                <xs:sequence>
+                    <xs:element name="a" type="xs:float"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/extension_base/mod.rs
+++ b/xsd-parser-rs/src/tests/extension_base/mod.rs
@@ -1,0 +1,43 @@
+use super::utils;
+
+#[test]
+fn deserialization_works() {
+    mod expected {
+        use macro_utils::*;
+        use std::io::{Read, Write};
+        use std::str::FromStr;
+        use xsd_types::utils;
+        use yaserde::{YaDeserialize, YaSerialize};
+
+        include!("expected.rs");
+    }
+
+    let ser = include_str!("example.xml");
+
+    let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
+
+    assert_eq!(
+        de,
+        expected::FooType {
+            a: 150.0,
+            b: 3,
+            c: "string".to_string(),
+        }
+    );
+}
+
+#[test]
+fn generator_does_not_panic() {
+    let rust_code = utils::generate(include_str!("input.xsd"));
+    println!("{}", rust_code)
+}
+
+#[test]
+fn generator_output_has_correct_ast() {
+    let expected = include_str!("expected.rs");
+    let actual = utils::generate(include_str!("input.xsd"));
+
+    text_diff::print_diff(expected, &actual, "\n");
+
+    utils::assert_ast_eq(expected, &actual)
+}

--- a/xsd-parser-rs/src/tests/extension_base/mod.rs
+++ b/xsd-parser-rs/src/tests/extension_base/mod.rs
@@ -3,10 +3,7 @@ use super::utils;
 #[test]
 fn deserialization_works() {
     mod expected {
-        use macro_utils::*;
         use std::io::{Read, Write};
-        use std::str::FromStr;
-        use xsd_types::utils;
         use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
@@ -28,16 +25,10 @@ fn deserialization_works() {
 
 #[test]
 fn generator_does_not_panic() {
-    let rust_code = utils::generate(include_str!("input.xsd"));
-    println!("{}", rust_code)
+    println!("{}", utils::generate(include_str!("input.xsd")))
 }
 
 #[test]
 fn generator_output_has_correct_ast() {
-    let expected = include_str!("expected.rs");
-    let actual = utils::generate(include_str!("input.xsd"));
-
-    text_diff::print_diff(expected, &actual, "\n");
-
-    utils::assert_ast_eq(expected, &actual)
+    utils::ast_test(include_str!("input.xsd"), include_str!("expected.rs"));
 }

--- a/xsd-parser-rs/src/tests/extension_base_multilayer/example.xml
+++ b/xsd-parser-rs/src/tests/extension_base_multilayer/example.xml
@@ -1,0 +1,7 @@
+<exam:Foo xmlns:exam="http://example.com">
+  <exam:Messages>
+    <exam:aa>3</exam:aa>
+    <exam:bb>qwe</exam:bb>
+    <exam:a>rty</exam:a>
+  </exam:Messages>
+</exam:Foo>

--- a/xsd-parser-rs/src/tests/extension_base_multilayer/expected.rs
+++ b/xsd-parser-rs/src/tests/extension_base_multilayer/expected.rs
@@ -1,0 +1,29 @@
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct BarType {
+    #[yaserde(prefix = "tns", rename = "aa")]
+    pub aa: i32,
+
+    #[yaserde(prefix = "tns", rename = "bb")]
+    pub bb: String,
+}
+
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct FooType {
+    #[yaserde(prefix = "tns", rename = "Messages")]
+    pub messages: MessagesType,
+}
+
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct MessagesType {
+    #[yaserde(prefix = "tns", rename = "a")]
+    pub a: String,
+
+    #[yaserde(prefix = "tns", rename = "aa")]
+    pub aa: i32,
+
+    #[yaserde(prefix = "tns", rename = "bb")]
+    pub bb: String,
+}

--- a/xsd-parser-rs/src/tests/extension_base_multilayer/input.xsd
+++ b/xsd-parser-rs/src/tests/extension_base_multilayer/input.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+
+    <xs:complexType name="BarType">
+        <xs:sequence>
+            <xs:element name="aa" type="xs:int"/>
+            <xs:element name="bb" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="FooType">
+        <xs:sequence>
+            <xs:element name="Messages">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="tns:BarType">
+                            <xs:sequence>
+                                <xs:element name="a" type="xs:string"/>
+                            </xs:sequence>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/extension_base_multilayer/mod.rs
+++ b/xsd-parser-rs/src/tests/extension_base_multilayer/mod.rs
@@ -13,7 +13,16 @@ fn deserialization_works() {
 
     let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
 
-    assert_eq!(de, expected::FooType { min: 1, max: 2 });
+    assert_eq!(
+        de,
+        expected::FooType {
+            messages: expected::MessagesType {
+                aa: 3,
+                bb: "qwe".to_string(),
+                a: "rty".to_string()
+            }
+        }
+    );
 }
 
 #[test]

--- a/xsd-parser-rs/src/tests/extension_base_two_files/example.xml
+++ b/xsd-parser-rs/src/tests/extension_base_two_files/example.xml
@@ -1,0 +1,5 @@
+<exam:Foo xmlns:exam="http://example.com" xmlns:oth="http://other.example.com">
+  <oth:b>3</oth:b>
+  <oth:c>string</oth:c>
+  <exam:a>1.5E2</exam:a>
+</exam:Foo>

--- a/xsd-parser-rs/src/tests/extension_base_two_files/expected.rs
+++ b/xsd-parser-rs/src/tests/extension_base_two_files/expected.rs
@@ -1,0 +1,16 @@
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(
+    prefix = "tns",
+    namespace = "tns: http://example.com",
+    namespace = "tns2: http://other.example.com"
+)]
+pub struct FooType {
+    #[yaserde(prefix = "tns", rename = "a")]
+    pub a: f64,
+
+    #[yaserde(prefix = "tns2", rename = "b")]
+    pub b: i32,
+
+    #[yaserde(prefix = "tns2", rename = "c")]
+    pub c: String,
+}

--- a/xsd-parser-rs/src/tests/extension_base_two_files/input.xsd
+++ b/xsd-parser-rs/src/tests/extension_base_two_files/input.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           xmlns:tns2="http://other.example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+
+    <xs:import namespace="http://other.example.com" schemaLocation="input2.xsd"/>
+
+    <xs:complexType name="FooType">
+        <xs:complexContent>
+            <xs:extension base="tns2:BarType">
+                <xs:sequence>
+                    <xs:element name="a" type="xs:float"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/extension_base_two_files/input2.xsd
+++ b/xsd-parser-rs/src/tests/extension_base_two_files/input2.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://other.example.com"
+           targetNamespace="http://other.example.com"
+           elementFormDefault="qualified">
+
+    <xs:complexType name="BarType">
+        <xs:sequence>
+            <xs:element name="b" type="xs:int"/>
+            <xs:element name="c" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+</xs:schema>

--- a/xsd-parser-rs/src/tests/extension_base_two_files/mod.rs
+++ b/xsd-parser-rs/src/tests/extension_base_two_files/mod.rs
@@ -13,7 +13,14 @@ fn deserialization_works() {
 
     let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
 
-    assert_eq!(de, expected::FooType { min: 1, max: 2 });
+    assert_eq!(
+        de,
+        expected::FooType {
+            a: 150.0,
+            b: 3,
+            c: "string".to_string(),
+        }
+    );
 }
 
 #[test]
@@ -22,6 +29,7 @@ fn generator_does_not_panic() {
 }
 
 #[test]
+#[ignore]
 fn generator_output_has_correct_ast() {
     utils::ast_test(include_str!("input.xsd"), include_str!("expected.rs"));
 }

--- a/xsd-parser-rs/src/tests/mod.rs
+++ b/xsd-parser-rs/src/tests/mod.rs
@@ -1,6 +1,15 @@
 #[macro_use]
 mod utils;
+mod any;
 mod choice;
 mod complex_type;
+mod enumeration;
 mod extension_base;
+mod extension_base_multilayer;
+mod extension_base_two_files;
+mod ref_to_attribute;
+mod rename_only_where_needed;
 mod simple_type;
+mod type_name_clash;
+mod union;
+mod xsd_string;

--- a/xsd-parser-rs/src/tests/mod.rs
+++ b/xsd-parser-rs/src/tests/mod.rs
@@ -1,0 +1,6 @@
+#[macro_use]
+mod utils;
+mod choice;
+mod complex_type;
+mod extension_base;
+mod simple_type;

--- a/xsd-parser-rs/src/tests/ref_to_attribute/example.xml
+++ b/xsd-parser-rs/src/tests/ref_to_attribute/example.xml
@@ -1,0 +1,1 @@
+<exam:Foo exam:id="abcd" xmlns:exam="http://example.com"/>

--- a/xsd-parser-rs/src/tests/ref_to_attribute/expected.rs
+++ b/xsd-parser-rs/src/tests/ref_to_attribute/expected.rs
@@ -1,0 +1,6 @@
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct FooType {
+    #[yaserde(attribute)]
+    pub id: String,
+}

--- a/xsd-parser-rs/src/tests/ref_to_attribute/input.xsd
+++ b/xsd-parser-rs/src/tests/ref_to_attribute/input.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+
+    <xs:attribute name="id">
+        <xs:simpleType>
+            <xs:restriction base="xs:string" />
+        </xs:simpleType>
+    </xs:attribute>
+
+    <xs:complexType name="FooType" >
+        <xs:attribute ref="tns:id" />
+    </xs:complexType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/ref_to_attribute/mod.rs
+++ b/xsd-parser-rs/src/tests/ref_to_attribute/mod.rs
@@ -13,7 +13,12 @@ fn deserialization_works() {
 
     let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
 
-    assert_eq!(de, expected::FooType { min: 1, max: 2 });
+    assert_eq!(
+        de,
+        expected::FooType {
+            id: "abcd".to_string()
+        }
+    );
 }
 
 #[test]
@@ -22,6 +27,7 @@ fn generator_does_not_panic() {
 }
 
 #[test]
+#[ignore]
 fn generator_output_has_correct_ast() {
     utils::ast_test(include_str!("input.xsd"), include_str!("expected.rs"));
 }

--- a/xsd-parser-rs/src/tests/rename_only_where_needed/example.xml
+++ b/xsd-parser-rs/src/tests/rename_only_where_needed/example.xml
@@ -1,0 +1,4 @@
+<exam:Foo xmlns:exam="http://example.com">
+  <exam:min>1</exam:min>
+  <exam:max>2</exam:max>
+</exam:Foo>

--- a/xsd-parser-rs/src/tests/rename_only_where_needed/expected.rs
+++ b/xsd-parser-rs/src/tests/rename_only_where_needed/expected.rs
@@ -1,0 +1,9 @@
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct FooType {
+    #[yaserde(prefix = "tns")]
+    pub min: i32,
+
+    #[yaserde(prefix = "tns")]
+    pub max: i32,
+}

--- a/xsd-parser-rs/src/tests/rename_only_where_needed/input.xsd
+++ b/xsd-parser-rs/src/tests/rename_only_where_needed/input.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+    <xs:complexType name="FooType">
+        <xs:sequence>
+            <xs:element name="min" type="xs:int"/>
+            <xs:element name="max" type="xs:int"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/rename_only_where_needed/mod.rs
+++ b/xsd-parser-rs/src/tests/rename_only_where_needed/mod.rs
@@ -22,6 +22,7 @@ fn generator_does_not_panic() {
 }
 
 #[test]
+#[ignore]
 fn generator_output_has_correct_ast() {
     utils::ast_test(include_str!("input.xsd"), include_str!("expected.rs"));
 }

--- a/xsd-parser-rs/src/tests/simple_type/example.xml
+++ b/xsd-parser-rs/src/tests/simple_type/example.xml
@@ -1,0 +1,1 @@
+<exam:Foo xmlns:exam="http://example.com">string</exam:Foo>

--- a/xsd-parser-rs/src/tests/simple_type/expected.rs
+++ b/xsd-parser-rs/src/tests/simple_type/expected.rs
@@ -1,0 +1,2 @@
+#[derive(Default, PartialEq, Debug, UtilsTupleSerDe)]
+pub struct FooType (pub String);

--- a/xsd-parser-rs/src/tests/simple_type/input.xsd
+++ b/xsd-parser-rs/src/tests/simple_type/input.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+    <xs:simpleType name="FooType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/simple_type/mod.rs
+++ b/xsd-parser-rs/src/tests/simple_type/mod.rs
@@ -1,0 +1,41 @@
+use super::utils;
+
+#[test]
+fn deserialization_works() {
+    mod expected {
+        use macro_utils::*;
+        use std::io::{Read, Write};
+        use std::str::FromStr;
+        use xsd_types::utils;
+        use yaserde::{YaDeserialize, YaSerialize};
+
+        trait Validate {
+            fn validate(&self) -> Result<(), String>;
+        }
+
+        include!("expected.rs");
+    }
+
+    let ser = include_str!("example.xml");
+
+    let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
+
+    assert_eq!(de, expected::FooType("string".to_string()));
+}
+
+#[test]
+fn generator_does_not_panic() {
+    let rust_code = utils::generate(include_str!("input.xsd"));
+    println!("{}", rust_code)
+}
+
+#[test]
+#[ignore] // Validation is not needed in this case
+fn generator_output_has_correct_ast() {
+    let expected = include_str!("expected.rs");
+    let actual = utils::generate(include_str!("input.xsd"));
+
+    text_diff::print_diff(expected, &actual, "\n");
+
+    utils::assert_ast_eq(expected, &actual)
+}

--- a/xsd-parser-rs/src/tests/simple_type/mod.rs
+++ b/xsd-parser-rs/src/tests/simple_type/mod.rs
@@ -25,17 +25,11 @@ fn deserialization_works() {
 
 #[test]
 fn generator_does_not_panic() {
-    let rust_code = utils::generate(include_str!("input.xsd"));
-    println!("{}", rust_code)
+    println!("{}", utils::generate(include_str!("input.xsd")))
 }
 
 #[test]
 #[ignore] // Validation is not needed in this case
 fn generator_output_has_correct_ast() {
-    let expected = include_str!("expected.rs");
-    let actual = utils::generate(include_str!("input.xsd"));
-
-    text_diff::print_diff(expected, &actual, "\n");
-
-    utils::assert_ast_eq(expected, &actual)
+    utils::ast_test(include_str!("input.xsd"), include_str!("expected.rs"));
 }

--- a/xsd-parser-rs/src/tests/type_name_clash/example.xml
+++ b/xsd-parser-rs/src/tests/type_name_clash/example.xml
@@ -1,0 +1,1 @@
+<exam:Foo a="aaa" b="bbb" xmlns:exam="http://example.com"/>

--- a/xsd-parser-rs/src/tests/type_name_clash/expected.rs
+++ b/xsd-parser-rs/src/tests/type_name_clash/expected.rs
@@ -1,0 +1,11 @@
+// TODO: think how it can actually be generated
+
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct FooType {
+    #[yaserde(attribute, rename = "b")]
+    pub b: Option<String>,
+
+    #[yaserde(attribute, rename = "a")]
+    pub a: Option<String>,
+}

--- a/xsd-parser-rs/src/tests/type_name_clash/input.xsd
+++ b/xsd-parser-rs/src/tests/type_name_clash/input.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+    <xs:complexType name="BarType">
+        <xs:attribute name="a" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="FooType">
+        <xs:sequence>
+            <xs:element name="Bar">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="tns:BarType">
+                            <xs:attribute name="b" type="xs:string" />
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/type_name_clash/mod.rs
+++ b/xsd-parser-rs/src/tests/type_name_clash/mod.rs
@@ -13,7 +13,13 @@ fn deserialization_works() {
 
     let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
 
-    assert_eq!(de, expected::FooType { min: 1, max: 2 });
+    assert_eq!(
+        de,
+        expected::FooType {
+            a: Some("aaa".to_string()),
+            b: Some("bbb".to_string())
+        }
+    );
 }
 
 #[test]
@@ -22,6 +28,7 @@ fn generator_does_not_panic() {
 }
 
 #[test]
+#[ignore]
 fn generator_output_has_correct_ast() {
     utils::ast_test(include_str!("input.xsd"), include_str!("expected.rs"));
 }

--- a/xsd-parser-rs/src/tests/union/example.xml
+++ b/xsd-parser-rs/src/tests/union/example.xml
@@ -1,0 +1,1 @@
+<exam:Foo xmlns:exam="http://example.com">string</exam:Foo>

--- a/xsd-parser-rs/src/tests/union/expected.rs
+++ b/xsd-parser-rs/src/tests/union/expected.rs
@@ -1,0 +1,2 @@
+#[derive(Default, PartialEq, Debug, UtilsTupleSerDe)]
+pub struct FooType(pub String);

--- a/xsd-parser-rs/src/tests/union/input.xsd
+++ b/xsd-parser-rs/src/tests/union/input.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+
+    <xs:simpleType name="FooType">
+        <xs:union memberTypes="xs:int xs:string" />
+    </xs:simpleType>
+
+    <xs:element name="Foo" type="tns:FooType"/>
+</xs:schema>

--- a/xsd-parser-rs/src/tests/union/mod.rs
+++ b/xsd-parser-rs/src/tests/union/mod.rs
@@ -3,7 +3,10 @@ use super::utils;
 #[test]
 fn deserialization_works() {
     mod expected {
+        use macro_utils::*;
         use std::io::{Read, Write};
+        use std::str::FromStr;
+        use xsd_types::utils;
         use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
@@ -13,15 +16,17 @@ fn deserialization_works() {
 
     let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
 
-    assert_eq!(de, expected::FooType { min: 1, max: 2 });
+    assert_eq!(de, expected::FooType("string".to_string()));
 }
 
 #[test]
+#[ignore]
 fn generator_does_not_panic() {
     println!("{}", utils::generate(include_str!("input.xsd")))
 }
 
 #[test]
+#[ignore]
 fn generator_output_has_correct_ast() {
     utils::ast_test(include_str!("input.xsd"), include_str!("expected.rs"));
 }

--- a/xsd-parser-rs/src/tests/utils.rs
+++ b/xsd-parser-rs/src/tests/utils.rs
@@ -1,0 +1,29 @@
+use crate::generator::Generator;
+use crate::parser::parse;
+use crate::yaserde_generator::YaserdeGenerator;
+use std::fmt::Write;
+
+pub fn generate(input: &str) -> String {
+    let f = parse(input).unwrap();
+
+    let gen = YaserdeGenerator::new(&f);
+    let mut output = String::new();
+
+    for ty in f.types {
+        write!(output, "{}", gen.gen_rs_entity(&ty)).unwrap();
+    }
+
+    output
+}
+
+/// Checks if AST of two code fragments are equivalent.
+/// Here we compare only AST, so anything not related
+/// to AST is ignored, like:
+///  - comments
+///  - formatting
+pub fn assert_ast_eq(expected: &str, actual: &str) {
+    let expected = syn::parse_file(&expected).unwrap();
+    let actual = syn::parse_file(&actual).unwrap();
+
+    assert_eq!(expected, actual)
+}

--- a/xsd-parser-rs/src/tests/utils.rs
+++ b/xsd-parser-rs/src/tests/utils.rs
@@ -27,3 +27,16 @@ pub fn assert_ast_eq(expected: &str, actual: &str) {
 
     assert_eq!(expected, actual)
 }
+
+pub fn ast_test(input_xsd: &str, expected_rs: &str) {
+    let expected = expected_rs;
+    let actual = generate(input_xsd);
+
+    println!("=== expected:\n{}", expected);
+    println!("=== actual:\n{}", actual);
+    println!("=== diff:\n");
+
+    text_diff::print_diff(expected, &actual, "\n");
+
+    assert_ast_eq(expected, &actual)
+}

--- a/xsd-parser-rs/src/tests/xsd_string/example.xml
+++ b/xsd-parser-rs/src/tests/xsd_string/example.xml
@@ -1,0 +1,3 @@
+<exam:Foo xmlns:exam="http://example.com">
+  <exam:Text>abcd</exam:Text>
+</exam:Foo>

--- a/xsd-parser-rs/src/tests/xsd_string/expected.rs
+++ b/xsd-parser-rs/src/tests/xsd_string/expected.rs
@@ -1,0 +1,6 @@
+#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub struct FooType {
+    #[yaserde(prefix = "tns", rename = "Text")]
+    pub text: String,
+}

--- a/xsd-parser-rs/src/tests/xsd_string/input.xsd
+++ b/xsd-parser-rs/src/tests/xsd_string/input.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+    <xsd:complexType name="FooType">
+        <xsd:sequence>
+            <xsd:element name="Text" type="xsd:string"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="Foo" type="tns:FooType"/>
+</xsd:schema>

--- a/xsd-parser-rs/src/tests/xsd_string/mod.rs
+++ b/xsd-parser-rs/src/tests/xsd_string/mod.rs
@@ -13,7 +13,12 @@ fn deserialization_works() {
 
     let de: expected::FooType = yaserde::de::from_str(&ser).unwrap();
 
-    assert_eq!(de, expected::FooType { min: 1, max: 2 });
+    assert_eq!(
+        de,
+        expected::FooType {
+            text: "abcd".to_string()
+        }
+    );
 }
 
 #[test]
@@ -22,6 +27,7 @@ fn generator_does_not_panic() {
 }
 
 #[test]
+#[ignore]
 fn generator_output_has_correct_ast() {
     utils::ast_test(include_str!("input.xsd"), include_str!("expected.rs"));
 }

--- a/xsd-types/src/lib.rs
+++ b/xsd-types/src/lib.rs
@@ -1,8 +1,7 @@
-#[macro_use]
+#[cfg_attr(test, macro_use)]
 extern crate log;
-#[macro_use]
+#[cfg_attr(test, macro_use)]
 extern crate yaserde_derive;
 
 pub mod types;
-
-mod utils;
+pub mod utils;

--- a/xsd-types/src/types/decimal.rs
+++ b/xsd-types/src/types/decimal.rs
@@ -41,7 +41,7 @@ impl YaDeserialize for Decimal {
 
 impl YaSerialize for Decimal {
     fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
-        utils::yaserde::serialize(self, "Decimal", writer, |s| Ok(s.value.to_string()))
+        utils::yaserde::serialize(self, "Decimal", writer, |s| s.value.to_string())
     }
 }
 

--- a/xsd-types/src/types/duration.rs
+++ b/xsd-types/src/types/duration.rs
@@ -282,9 +282,7 @@ impl YaDeserialize for Duration {
 
 impl YaSerialize for Duration {
     fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
-        utils::yaserde::serialize(self, "Duration", writer, |s| {
-            s.to_string()
-        })
+        utils::yaserde::serialize(self, "Duration", writer, |s| s.to_string().unwrap())
     }
 }
 

--- a/xsd-types/src/types/integer.rs
+++ b/xsd-types/src/types/integer.rs
@@ -43,7 +43,7 @@ impl YaDeserialize for Integer {
 
 impl YaSerialize for Integer {
     fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
-        utils::yaserde::serialize(self, "Integer", writer, |s| Ok(s.value.to_str_radix(10)))
+        utils::yaserde::serialize(self, "Integer", writer, |s| s.value.to_str_radix(10))
     }
 }
 

--- a/xsd-types/src/utils/yaserde.rs
+++ b/xsd-types/src/utils/yaserde.rs
@@ -5,7 +5,7 @@ pub fn serialize<S, W: Write>(
     self_bypass: &S,
     default_name: &str,
     writer: &mut ser::Serializer<W>,
-    ser_fn: impl FnOnce(&S) -> Result<String, String>,
+    ser_fn: impl FnOnce(&S) -> String,
 ) -> Result<(), String> {
     let name = writer
         .get_start_event_name()
@@ -19,7 +19,7 @@ pub fn serialize<S, W: Write>(
 
     writer
         .write(xml::writer::XmlEvent::characters(
-            ser_fn(self_bypass)?.as_str(),
+            ser_fn(self_bypass).as_str(),
         ))
         .map_err(|_e| "Element value write failed".to_string())?;
 


### PR DESCRIPTION
Closes #36 

It is easier to start reading this PR from [readme](https://github.com/lumeohq/xsd-parser-rs/compare/add-tests-for-generated-code?expand=1#diff-7e906fdbbf2ca4f9a998c5b849a83c2b)