### PR TITLE
Issue 31: Add support for union element

### DIFF
--- a/xsd-parser-rs/src/generator/mod.rs
+++ b/xsd-parser-rs/src/generator/mod.rs
@@ -131,7 +131,7 @@ pub trait Generator {
     fn gen_enum(&self, en: &Enum) -> String {
         let name = self.format_type(en.name.as_str());
         format!(
-            "{comment}{macros}\npub enum {name} {{\n{cases}\n __Unknown__({typename})\n\
+            "{comment}{macros}\npub enum {name} {{\n{cases}\n    __Unknown__({typename})\n\
             }}\n\n\
             {default}\n\n\
             {validation}\n\n\
@@ -164,11 +164,12 @@ pub trait Generator {
     }
 
     fn gen_enum_case(&self, ec: &EnumCase) -> String {
-        let name = self.format_type(ec.name.as_str());
-        let comment = self.format_comment(ec.comment.as_deref(), 2);
-        let macros: Cow<'static, str> = if name.as_ref() == ec.name.as_str() {
+        let name = self.get_enum_case_name(ec);
+        let comment = self.format_comment(ec.comment.as_deref(), 4);
+        let macros: Cow<'static, str> = if name == ec.name {
             "".into()
         } else {
+            // if rename required
             self.enum_case_macro(ec)
         };
         match &ec.type_name {
@@ -189,6 +190,14 @@ pub trait Generator {
                 macros = macros
             ),
         }
+    }
+
+    fn get_enum_case_name(&self, ec: &EnumCase) -> String {
+        self.format_type(ec.name.as_str())
+            .split("::")
+            .last()
+            .unwrap()
+            .to_string()
     }
 
     fn get_struct_field(&self, sf: &StructField) -> String {

--- a/xsd-parser-rs/src/generator/utils.rs
+++ b/xsd-parser-rs/src/generator/utils.rs
@@ -89,10 +89,13 @@ pub fn match_built_in_type(type_name: &str) -> &'static str {
 }
 
 pub fn sanitize(s: String) -> String {
-    if s.chars().next().unwrap().is_numeric() || RS_KEYWORDS.contains(&s.as_str()) {
-        return format!("_{}", s);
+    if s.is_empty() {
+        s
+    } else if s.chars().next().unwrap().is_numeric() || RS_KEYWORDS.contains(&s.as_str()) {
+        format!("_{}", s)
+    } else {
+        s
     }
-    s
 }
 
 const RS_KEYWORDS: &[&str] = &[

--- a/xsd-parser-rs/src/main.rs
+++ b/xsd-parser-rs/src/main.rs
@@ -19,7 +19,8 @@ use crate::parser::parse;
 use crate::yaserde_generator::YaserdeGenerator;
 
 fn main() {
-    let text = load_file("xsd/onvif.xsd");
+    let text = load_file("xsd_external/b-2.xsd");
+    //let text = load_file("xsd/onvif.xsd");
     if let Ok(f) = parse(text.as_str()) {
         let gen = YaserdeGenerator::new(&f);
         for ty in f.types {

--- a/xsd-parser-rs/src/parser/constants.rs
+++ b/xsd-parser-rs/src/parser/constants.rs
@@ -15,4 +15,5 @@ pub mod attribute {
     pub const SCHEMA_LOCATION: &str = "schemaLocation";
     pub const MIN_OCCURS: &str = "minOccurs";
     pub const MAX_OCCURS: &str = "maxOccurs";
+    pub const MEMBER_TYPES: &str = "memberTypes";
 }

--- a/xsd-parser-rs/src/parser/mod.rs
+++ b/xsd-parser-rs/src/parser/mod.rs
@@ -15,6 +15,7 @@ mod simple_content;
 mod simple_type;
 mod tests;
 pub mod types;
+mod union;
 mod utils;
 pub mod xsd_elements;
 

--- a/xsd-parser-rs/src/parser/node_parser.rs
+++ b/xsd-parser-rs/src/parser/node_parser.rs
@@ -13,6 +13,7 @@ use crate::parser::sequence::parse_sequence;
 use crate::parser::simple_content::parse_simple_content;
 use crate::parser::simple_type::parse_simple_type;
 use crate::parser::types::RsEntity;
+use crate::parser::union::parse_union;
 use crate::parser::xsd_elements::{ElementType, XsdNode};
 
 pub fn parse_node(node: &Node, parent: &Node) -> RsEntity {
@@ -31,6 +32,7 @@ pub fn parse_node(node: &Node, parent: &Node) -> RsEntity {
         Sequence => parse_sequence(node, parent),
         SimpleContent => parse_simple_content(node),
         SimpleType => parse_simple_type(node, parent),
+        Union => parse_union(node),
 
         _ => {
             unreachable!("{:?}", node);

--- a/xsd-parser-rs/src/parser/sequence.rs
+++ b/xsd-parser-rs/src/parser/sequence.rs
@@ -3,8 +3,8 @@ use std::cell::RefCell;
 use roxmltree::Node;
 
 use crate::parser::node_parser::parse_node;
-use crate::parser::types::{Enum, RsEntity, Struct, StructField, StructFieldSource, TypeModifier};
-use crate::parser::utils::{get_documentation, get_parent_name};
+use crate::parser::types::{RsEntity, Struct, StructField, TypeModifier};
+use crate::parser::utils::{enum_to_field, get_documentation, get_parent_name};
 
 pub fn parse_sequence(sequence: &Node, parent: &Node) -> RsEntity {
     let name = get_parent_name(sequence);
@@ -34,14 +34,4 @@ fn elements_to_fields(sequence: &Node, parent_name: &str) -> Vec<StructField> {
             _ => unreachable!("\nError: {:?}\n{:?}", n, parse_node(&n, sequence)),
         })
         .collect()
-}
-
-fn enum_to_field(en: Enum) -> StructField {
-    StructField {
-        name: en.name.clone(),
-        type_name: en.name.clone(),
-        subtypes: vec![RsEntity::Enum(en)],
-        source: StructFieldSource::Element,
-        ..Default::default()
-    }
 }

--- a/xsd-parser-rs/src/parser/simple_type.rs
+++ b/xsd-parser-rs/src/parser/simple_type.rs
@@ -24,7 +24,7 @@ pub fn parse_simple_type(node: &Node, parent: &Node) -> RsEntity {
         );
 
     let mut content_type = match content.xsd_type() {
-        ElementType::Union => unimplemented!(), //TODO: Add union parser (No in ONVIF)
+        ElementType::Union => parse_node(&content, node),
         ElementType::List => parse_node(&content, node),
         ElementType::Restriction(RestrictionType::SimpleType) => simple_type_restriction(&content),
         _ => unreachable!("Invalid content type of SimpleType {:?}", content),

--- a/xsd-parser-rs/src/parser/types.rs
+++ b/xsd-parser-rs/src/parser/types.rs
@@ -118,7 +118,7 @@ pub struct TupleStruct {
     pub facets: Vec<Facet>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Enum {
     pub name: String,
     pub cases: Vec<EnumCase>,
@@ -136,7 +136,7 @@ pub enum TypeModifier {
     Empty,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct EnumCase {
     pub name: String,
     pub comment: Option<String>,

--- a/xsd-parser-rs/src/parser/union.rs
+++ b/xsd-parser-rs/src/parser/union.rs
@@ -1,0 +1,110 @@
+use roxmltree::Node;
+
+use crate::parser::constants::attribute;
+use crate::parser::node_parser::parse_node;
+use crate::parser::types::{Enum, EnumCase, RsEntity, Struct};
+use crate::parser::utils::{
+    attributes_to_fields, enum_to_field, find_child, get_documentation, get_parent_name,
+};
+use crate::parser::xsd_elements::{ElementType, XsdNode};
+use std::cell::RefCell;
+
+pub fn parse_union(union: &Node) -> RsEntity {
+    let mut cases = union
+        .attribute(attribute::MEMBER_TYPES)
+        .map(|s| create_enum_cases(s))
+        .unwrap_or_else(|| vec![]);
+
+    let subtypes = union
+        .children()
+        .filter(|e| e.is_element() && e.xsd_type() == ElementType::SimpleType)
+        .map(|st| parse_node(&st, union))
+        .collect::<Vec<RsEntity>>();
+
+    cases.append(
+        &mut subtypes
+            .iter()
+            .map(|rs_entity| EnumCase {
+                name: rs_entity.name().to_string(),
+                type_name: Some(rs_entity.name().to_string()),
+                ..Default::default()
+            })
+            .collect(),
+    );
+
+    let mut union_enum = Enum {
+        cases,
+        subtypes,
+        comment: get_documentation(union),
+        type_name: "String".into(),
+        ..Default::default()
+    };
+
+    let mut fields = attributes_to_fields(union);
+
+    if fields.is_empty() {
+        RsEntity::Enum(union_enum)
+    } else {
+        union_enum.name = format!("{}Choice", get_parent_name(union));
+        fields.push(enum_to_field(union_enum));
+        RsEntity::Struct(Struct {
+            fields: RefCell::new(fields),
+            ..Default::default()
+        })
+    }
+}
+
+fn create_enum_cases(member_types: &str) -> Vec<EnumCase> {
+    member_types
+        .split(" ")
+        .filter(|s| !s.is_empty())
+        .map(|mt| EnumCase {
+            name: mt.to_string(),
+            type_name: Some(mt.to_string()),
+            ..Default::default()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use crate::parser::types::RsEntity;
+    use crate::parser::union::{create_enum_cases, parse_union};
+    use crate::parser::utils::find_child;
+
+    #[test]
+    fn test_create_enum() {
+        let cases = create_enum_cases("Type1 Type2  Type3");
+        assert_eq!(cases.len(), 3);
+        assert_eq!(cases[0].name, "Type1");
+    }
+
+    #[test]
+    fn test_parse_union() {
+        let doc = roxmltree::Document::parse(
+            r#"
+    <xs:schema xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.onvif.org/ver10/schema">
+        <xs:simpleType name="SomeType">
+            <xs:annotation><xs:documentation>Some text</xs:documentation></xs:annotation>
+            <xs:union memberTypes="Type1 Type2" />
+        </xs:simpleType>
+    </xs:schema>
+    "#
+        ).unwrap();
+
+        let simple_type = find_child(&doc.root_element(), "simpleType").unwrap();
+        let union = find_child(&simple_type, "union").unwrap();
+
+        let result = parse_union(&union);
+
+        match result {
+            RsEntity::Enum(en) => {
+                assert_eq!(en.cases.len(), 2);
+                assert_eq!(en.cases[0].name, "Type1");
+                assert_eq!(en.cases[1].name, "Type2");
+                assert_eq!(en.name, String::default());
+            }
+            _ => unreachable!("Test Failed"),
+        }
+    }
+}

--- a/xsd-parser-rs/src/parser/utils.rs
+++ b/xsd-parser-rs/src/parser/utils.rs
@@ -6,7 +6,7 @@ use roxmltree::{Namespace, Node};
 
 use crate::parser::constants::attribute;
 use crate::parser::node_parser::parse_node;
-use crate::parser::types::{RsEntity, StructField};
+use crate::parser::types::{Enum, RsEntity, StructField, StructFieldSource};
 use crate::parser::xsd_elements::{ElementType, XsdNode};
 
 pub fn target_namespace<'a, 'input>(node: &Node<'a, 'input>) -> Option<&'a Namespace<'input>> {
@@ -53,4 +53,14 @@ pub fn attributes_to_fields(node: &Node) -> Vec<StructField> {
             _ => unreachable!("Invalid attribute parsing: {:?}", n),
         })
         .collect()
+}
+
+pub fn enum_to_field(en: Enum) -> StructField {
+    StructField {
+        name: en.name.clone(),
+        type_name: en.name.clone(),
+        subtypes: vec![RsEntity::Enum(en)],
+        source: StructFieldSource::Element,
+        ..Default::default()
+    }
 }

--- a/xsd-parser-rs/src/yaserde_generator.rs
+++ b/xsd-parser-rs/src/yaserde_generator.rs
@@ -63,7 +63,7 @@ impl<'input> Generator for YaserdeGenerator<'input> {
     }
 
     fn enum_case_macro(&self, ec: &EnumCase) -> Cow<'static, str> {
-        yaserde_for_enum_case(ec.name.as_str(), self.target_ns.as_ref()).into()
+        yaserde_for_enum_case(ec.name.as_str()).into()
     }
 }
 
@@ -95,7 +95,7 @@ fn yaserde_for_element(name: &str, target_namespace: Option<&roxmltree::Namespac
     }
 }
 
-fn yaserde_for_enum_case(name: &str, target_namespace: Option<&roxmltree::Namespace>) -> String {
+fn yaserde_for_enum_case(name: &str) -> String {
     let (prefix, field_name) = if let Some(index) = name.find(':') {
         (Some(&name[0..index]), &name[index + 1..])
     } else {
@@ -109,10 +109,6 @@ fn yaserde_for_enum_case(name: &str, target_namespace: Option<&roxmltree::Namesp
         ),
         None => format!("    #[yaserde(rename = \"{}\")]\n", field_name),
     }
-}
-
-fn yaserde_rename_macro(name: &str) -> String {
-    format!("    #[yaserde(rename = \"{}\")]\n", name)
 }
 
 fn yaserde_for_flatten_element() -> String {
@@ -132,13 +128,5 @@ mod test {
             yaserde_for_element("xop:Include", ns),
             "    #[yaserde(prefix = \"xop\", rename = \"Include\")]\n"
         );
-    }
-
-    #[test]
-    fn test_yaserde_rename_macro() {
-        assert_eq!(
-            yaserde_rename_macro("NTP"),
-            "    #[yaserde(rename = \"NTP\")]\n"
-        )
     }
 }

--- a/xsd-parser-rs/src/yaserde_generator.rs
+++ b/xsd-parser-rs/src/yaserde_generator.rs
@@ -63,7 +63,7 @@ impl<'input> Generator for YaserdeGenerator<'input> {
     }
 
     fn enum_case_macro(&self, ec: &EnumCase) -> Cow<'static, str> {
-        yaserde_rename_macro(ec.name.as_str()).into()
+        yaserde_for_enum_case(ec.name.as_str(), self.target_ns.as_ref()).into()
     }
 }
 
@@ -84,6 +84,22 @@ fn yaserde_for_element(name: &str, target_namespace: Option<&roxmltree::Namespac
         (Some(&name[0..index]), &name[index + 1..])
     } else {
         (target_namespace.and_then(|ns| ns.name()), name)
+    };
+
+    match prefix {
+        Some(p) => format!(
+            "    #[yaserde(prefix = \"{}\", rename = \"{}\")]\n",
+            p, field_name
+        ),
+        None => format!("    #[yaserde(rename = \"{}\")]\n", field_name),
+    }
+}
+
+fn yaserde_for_enum_case(name: &str, target_namespace: Option<&roxmltree::Namespace>) -> String {
+    let (prefix, field_name) = if let Some(index) = name.find(':') {
+        (Some(&name[0..index]), &name[index + 1..])
+    } else {
+        (None, name)
     };
 
     match prefix {

--- a/xsd_external/b-2.xsd
+++ b/xsd_external/b-2.xsd
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+
+OASIS takes no position regarding the validity or scope of any intellectual property or other rights that might be claimed to pertain to the implementation or use of the technology described in this document or the extent to which any license under such rights might or might not be available; neither does it represent that it has made any effort to identify any such rights. Information on OASIS's procedures with respect to rights in OASIS specifications can be found at the OASIS website. Copies of claims of rights made available for publication and any assurances of licenses to be made available, or the result of an attempt made to obtain a general license or permission for the use of such proprietary rights by implementors or users of this specification, can be obtained from the OASIS Executive Director.
+
+OASIS invites any interested party to bring to its attention any copyrights, patents or patent applications, or other proprietary rights which may cover technology that may be required to implement this specification. Please address the information to the OASIS Executive Director.
+
+Copyright (C) OASIS Open (2004-2006). All Rights Reserved.
+
+This document and translations of it may be copied and furnished to others, and derivative works that comment on or otherwise explain it or assist in its implementation may be prepared, copied, published and distributed, in whole or in part, without restriction of any kind, provided that the above copyright notice and this paragraph are included on all such copies and derivative works. However, this document itself may not be modified in any way, such as by removing the copyright notice or references to OASIS, except as needed for the purpose of developing OASIS specifications, in which case the procedures for copyrights defined in the OASIS Intellectual Property Rights document must be followed, or as required to translate it into languages other than English. 
+
+The limited permissions granted above are perpetual and will not be revoked by OASIS or its successors or assigns. 
+
+This document and the information contained herein is provided on an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+-->
+
+<xsd:schema 
+  targetNamespace="http://docs.oasis-open.org/wsn/b-2"   
+  xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2"
+  xmlns:wsa="http://www.w3.org/2005/08/addressing"
+  xmlns:wsrf-bf="http://docs.oasis-open.org/wsrf/bf-2"
+  xmlns:wstop="http://docs.oasis-open.org/wsn/t-1"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+  elementFormDefault="qualified"  attributeFormDefault="unqualified">
+
+<!-- ======================== Imports  ============================ -->
+  
+  <xsd:import namespace="http://www.w3.org/2005/08/addressing"
+              schemaLocation="http://www.w3.org/2005/08/addressing/ws-addr.xsd" 
+  />
+
+  <xsd:import namespace="http://docs.oasis-open.org/wsrf/bf-2"
+              schemaLocation="http://docs.oasis-open.org/wsrf/bf-2.xsd" 
+  />
+  <xsd:import namespace="http://docs.oasis-open.org/wsn/t-1"
+              schemaLocation="http://docs.oasis-open.org/wsn/t-1.xsd" 
+  />
+  
+<!-- ===================== Misc. Helper Types ===================== -->
+
+  <xsd:complexType name="QueryExpressionType" mixed="true">
+    <xsd:sequence>
+      <xsd:any minOccurs="0" maxOccurs="1" processContents="lax" />
+    </xsd:sequence>
+    <xsd:attribute name="Dialect" type="xsd:anyURI" use="required"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="TopicExpressionType" mixed="true">
+    <xsd:sequence>
+      <xsd:any minOccurs="0" maxOccurs="1" processContents="lax" />
+    </xsd:sequence>
+    <xsd:attribute name="Dialect" type="xsd:anyURI" use="required" />
+    <xsd:anyAttribute/>
+  </xsd:complexType>
+
+  <xsd:complexType name="FilterType">
+    <xsd:sequence>
+      <xsd:any minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="SubscriptionPolicyType">
+    <xsd:sequence>
+      <xsd:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+<!-- =============== Resource Property Related  =================== -->
+<!-- ======== Resource Properties for NotificationProducer ======== -->
+  <xsd:element name="TopicExpression" type="wsnt:TopicExpressionType"/>
+  <xsd:element name="FixedTopicSet" type="xsd:boolean" default="true"/>
+  <xsd:element name="TopicExpressionDialect" type="xsd:anyURI"/>
+              
+  <xsd:element name="NotificationProducerRP">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="wsnt:TopicExpression"        
+                     minOccurs="0" maxOccurs="unbounded" />
+        <xsd:element ref="wsnt:FixedTopicSet"        
+                     minOccurs="0" maxOccurs="1" />
+        <xsd:element ref="wsnt:TopicExpressionDialect"
+                     minOccurs="0" maxOccurs="unbounded" />
+        <xsd:element ref="wstop:TopicSet"
+                     minOccurs="0" maxOccurs="1" />
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+<!-- ======== Resource Properties for SubscriptionManager ========= -->       
+  <xsd:element name="ConsumerReference" 
+               type="wsa:EndpointReferenceType" />
+  <xsd:element name="Filter" type="wsnt:FilterType" />
+  <xsd:element name="SubscriptionPolicy"                                                                                                                                                                   		      type="wsnt:SubscriptionPolicyType" />
+
+
+  <xsd:element name="CreationTime" type="xsd:dateTime" />
+  
+  <xsd:element name="SubscriptionManagerRP" >
+    <xsd:complexType>
+      <xsd:sequence>
+         <xsd:element ref="wsnt:ConsumerReference"        
+                      minOccurs="1" maxOccurs="1" />
+         <xsd:element ref="wsnt:Filter"
+                      minOccurs="0" maxOccurs="1" />
+         <xsd:element ref="wsnt:SubscriptionPolicy" 
+                      minOccurs="0" maxOccurs="1" />
+         <xsd:element ref="wsnt:CreationTime" 
+                      minOccurs="0" maxOccurs="1" />
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+<!-- ================= Notification Metadata  ===================== -->
+  <xsd:element name="SubscriptionReference" 
+               type="wsa:EndpointReferenceType" />
+  <xsd:element name="Topic" 
+               type="wsnt:TopicExpressionType" />
+  <xsd:element name="ProducerReference" 
+               type="wsa:EndpointReferenceType" />
+
+<!-- ================== Message Helper Types  ===================== -->
+  <xsd:complexType name="NotificationMessageHolderType" >
+    <xsd:sequence>
+      <xsd:element ref="wsnt:SubscriptionReference" 
+                   minOccurs="0" maxOccurs="1" />
+      <xsd:element ref="wsnt:Topic" 
+                   minOccurs="0" maxOccurs="1" />
+      <xsd:element ref="wsnt:ProducerReference" 
+                   minOccurs="0" maxOccurs="1" />
+      <xsd:element name="Message">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:any namespace="##any" processContents="lax"
+                     minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="NotificationMessage"
+               type="wsnt:NotificationMessageHolderType"/>
+
+<!-- ========== Message Types for NotificationConsumer  =========== -->
+  <xsd:element name="Notify" >
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="wsnt:NotificationMessage"
+                     minOccurs="1" maxOccurs="unbounded" />
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+<!-- ========== Message Types for NotificationProducer  =========== -->
+
+  <xsd:simpleType name="AbsoluteOrRelativeTimeType">
+    <xsd:union memberTypes="xsd:dateTime xsd:duration" />
+  </xsd:simpleType>
+
+  <xsd:element name="CurrentTime" type="xsd:dateTime" />
+
+  <xsd:element name="TerminationTime" 
+               nillable="true" type="xsd:dateTime" />
+
+  <xsd:element name="ProducerProperties"
+               type="wsnt:QueryExpressionType" />
+
+  <xsd:element name="MessageContent"
+               type="wsnt:QueryExpressionType" />
+
+  <xsd:element name="UseRaw"><xsd:complexType/></xsd:element>
+
+  <xsd:element name="Subscribe" >
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="ConsumerReference" 
+                     type="wsa:EndpointReferenceType"
+                     minOccurs="1" maxOccurs="1" />
+        <xsd:element name="Filter" 
+                     type="wsnt:FilterType" 
+                     minOccurs="0" maxOccurs="1" />
+        <xsd:element name="InitialTerminationTime" 
+                     type="wsnt:AbsoluteOrRelativeTimeType"
+                     nillable="true"
+                     minOccurs="0" maxOccurs="1" />
+        <xsd:element name="SubscriptionPolicy"
+                     minOccurs="0" maxOccurs="1">
+          <xsd:complexType>
+            <xsd:sequence>
+              <xsd:any namespace="##any" processContents="lax"
+                       minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+          </xsd:complexType>
+        </xsd:element>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+        
+  <xsd:element name="SubscribeResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="SubscriptionReference" 
+                     type="wsa:EndpointReferenceType"
+                     minOccurs="1" maxOccurs="1" />
+        <xsd:element ref="wsnt:CurrentTime"
+                     minOccurs="0" maxOccurs="1" />
+        <xsd:element ref="wsnt:TerminationTime"
+                     minOccurs="0" maxOccurs="1" />
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+                  
+  <xsd:element name="GetCurrentMessage">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Topic" 
+                     type="wsnt:TopicExpressionType" />
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="GetCurrentMessageResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="SubscribeCreationFailedFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="SubscribeCreationFailedFault" 
+               type="wsnt:SubscribeCreationFailedFaultType"/>
+
+  <xsd:complexType name="InvalidFilterFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType">
+        <xsd:sequence>
+          <xsd:element name="UnknownFilter" type="xsd:QName"
+                       minOccurs="1" maxOccurs="unbounded"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="InvalidFilterFault"
+               type="wsnt:InvalidFilterFaultType"/>
+
+  <xsd:complexType name="TopicExpressionDialectUnknownFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="TopicExpressionDialectUnknownFault" 
+               type="wsnt:TopicExpressionDialectUnknownFaultType"/>
+
+  <xsd:complexType name="InvalidTopicExpressionFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="InvalidTopicExpressionFault" 
+               type="wsnt:InvalidTopicExpressionFaultType"/>
+
+  <xsd:complexType name="TopicNotSupportedFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="TopicNotSupportedFault" 
+               type="wsnt:TopicNotSupportedFaultType"/>
+
+  <xsd:complexType name="MultipleTopicsSpecifiedFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="MultipleTopicsSpecifiedFault" 
+               type="wsnt:MultipleTopicsSpecifiedFaultType"/>
+
+  <xsd:complexType name="InvalidProducerPropertiesExpressionFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="InvalidProducerPropertiesExpressionFault" 
+             type="wsnt:InvalidProducerPropertiesExpressionFaultType"/>
+
+  <xsd:complexType name="InvalidMessageContentExpressionFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="InvalidMessageContentExpressionFault" 
+             type="wsnt:InvalidMessageContentExpressionFaultType"/>
+
+  <xsd:complexType name="UnrecognizedPolicyRequestFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType">
+		<xsd:sequence>
+             <xsd:element name="UnrecognizedPolicy" type="xsd:QName"
+                           minOccurs="0" maxOccurs="unbounded"/>
+         </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="UnrecognizedPolicyRequestFault" 
+             type="wsnt:UnrecognizedPolicyRequestFaultType"/>
+
+  <xsd:complexType name="UnsupportedPolicyRequestFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType">
+		<xsd:sequence>
+             <xsd:element name="UnsupportedPolicy" type="xsd:QName"
+                           minOccurs="0" maxOccurs="unbounded"/>
+         </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="UnsupportedPolicyRequestFault" 
+             type="wsnt:UnsupportedPolicyRequestFaultType"/>
+
+  <xsd:complexType name="NotifyMessageNotSupportedFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="NotifyMessageNotSupportedFault" 
+             type="wsnt:NotifyMessageNotSupportedFaultType"/>
+
+  <xsd:complexType name="UnacceptableInitialTerminationTimeFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType">
+        <xsd:sequence>
+          <xsd:element name="MinimumTime" type="xsd:dateTime"/>
+          <xsd:element name="MaximumTime" type="xsd:dateTime"
+              minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="UnacceptableInitialTerminationTimeFault"
+              type="wsnt:UnacceptableInitialTerminationTimeFaultType"/>
+
+  <xsd:complexType name="NoCurrentMessageOnTopicFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="NoCurrentMessageOnTopicFault" 
+               type="wsnt:NoCurrentMessageOnTopicFaultType"/>
+
+<!-- ======== Message Types for PullPoint  ======================== -->
+  <xsd:element name="GetMessages">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="MaximumNumber" 
+                     type="xsd:nonNegativeInteger"
+                     minOccurs="0"/>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:anyAttribute/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="GetMessagesResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="wsnt:NotificationMessage" 
+                     minOccurs="0" maxOccurs="unbounded" />
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:anyAttribute/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="DestroyPullPoint">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:anyAttribute/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="DestroyPullPointResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:anyAttribute/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="UnableToGetMessagesFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:element name="UnableToGetMessagesFault" 
+               type="wsnt:UnableToGetMessagesFaultType"/>
+
+<xsd:complexType name="UnableToDestroyPullPointFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:element name="UnableToDestroyPullPointFault" 
+               type="wsnt:UnableToDestroyPullPointFaultType"/>
+
+<!-- ======== Message Types for Create PullPoint  ================= -->
+  <xsd:element name="CreatePullPoint">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:anyAttribute/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="CreatePullPointResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="PullPoint"
+                     type="wsa:EndpointReferenceType"/>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:anyAttribute/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="UnableToCreatePullPointFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="UnableToCreatePullPointFault" 
+               type="wsnt:UnableToCreatePullPointFaultType"/>
+
+<!-- ======== Message Types for Base SubscriptionManager  ========= -->
+  <xsd:element name="Renew">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="TerminationTime" 
+                     type="wsnt:AbsoluteOrRelativeTimeType"
+                     nillable="true"
+                     minOccurs="1" maxOccurs="1" />
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="RenewResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="wsnt:TerminationTime" 
+                      minOccurs="1" maxOccurs="1" />
+        <xsd:element ref="wsnt:CurrentTime" 
+                      minOccurs="0" maxOccurs="1" />
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="UnacceptableTerminationTimeFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType">
+        <xsd:sequence>
+          <xsd:element name="MinimumTime" type="xsd:dateTime"/>
+          <xsd:element name="MaximumTime" type="xsd:dateTime"
+              minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="UnacceptableTerminationTimeFault"
+              type="wsnt:UnacceptableTerminationTimeFaultType"/>
+
+  <xsd:element name="Unsubscribe">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="UnsubscribeResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="UnableToDestroySubscriptionFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="UnableToDestroySubscriptionFault" 
+               type="wsnt:UnableToDestroySubscriptionFaultType"/>
+
+<!-- ====== Message Types for Pausable SubscriptionManager  ======= -->
+
+  <xsd:element name="PauseSubscription">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="PauseSubscriptionResponse" >
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="ResumeSubscription">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="ResumeSubscriptionResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" processContents="lax"
+                 minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="PauseFailedFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="PauseFailedFault" 
+               type="wsnt:PauseFailedFaultType"/>
+
+  <xsd:complexType name="ResumeFailedFaultType">
+    <xsd:complexContent>
+      <xsd:extension base="wsrf-bf:BaseFaultType"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="ResumeFailedFault" 
+               type="wsnt:ResumeFailedFaultType"/>
+
+</xsd:schema>

--- a/xsd_external/bf-2.xsd
+++ b/xsd_external/bf-2.xsd
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+   OASIS takes no position regarding the validity or scope of any intellectual property or other rights that might be claimed to pertain to the implementation or use of the technology described in this document or the extent to which any license under such rights might or might not be available; neither does it represent that it has made any effort to identify any such rights. Information on OASIS's procedures with respect to rights in OASIS specifications can be found at the OASIS website. Copies of claims of rights made available for publication and any assurances of licenses to be made available, or the result of an attempt made to obtain a general license or permission for the use of such proprietary rights by implementers or users of this specification, can be obtained from the OASIS Executive Director. 
+
+OASIS invites any interested party to bring to its attention any copyrights, patents or patent applications, or other proprietary rights which may cover technology that may be required to implement this specification. Please address the information to the OASIS Executive Director. 
+
+Copyright (C) OASIS Open (2005). All Rights Reserved. 
+
+This document and translations of it may be copied and furnished to others, and derivative works that comment on or otherwise explain it or assist in its implementation may be prepared, copied, published and distributed, in whole or in part, without restriction of any kind, provided that the above copyright notice and this paragraph are included on all such copies and derivative works. However, this document itself may not be modified in any way, such as by removing the copyright notice or references to OASIS, except as needed for the purpose of developing OASIS specifications, in which case the procedures for copyrights defined in the OASIS Intellectual Property Rights document must be followed, or as required to translate it into languages other than English. 
+
+The limited permissions granted above are perpetual and will not be revoked by OASIS or its successors or assigns. 
+
+This document and the information contained herein is provided on an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. 
+-->
+
+<xsd:schema 
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:wsa="http://www.w3.org/2005/08/addressing"
+  xmlns:wsrf-bf=
+    "http://docs.oasis-open.org/wsrf/bf-2" 
+  elementFormDefault="qualified" attributeFormDefault="unqualified" 
+  targetNamespace=
+    "http://docs.oasis-open.org/wsrf/bf-2">
+  <xsd:import
+     namespace="http://www.w3.org/2005/08/addressing" 
+     schemaLocation=
+              "http://www.w3.org/2005/08/addressing/ws-addr.xsd"/>
+              
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace" 
+              schemaLocation="http://www.w3.org/2001/xml.xsd">
+    <xsd:annotation>
+      <xsd:documentation>
+        Get access to the xml: attribute groups for xml:lang as declared on 'schema'
+        and 'documentation' below
+      </xsd:documentation> 
+    </xsd:annotation>
+  </xsd:import>
+<!-- ====================== BaseFault Types ======================= -->
+      
+  <xsd:element name="BaseFault" type="wsrf-bf:BaseFaultType"/>
+  
+  <xsd:complexType name="BaseFaultType">
+    <xsd:sequence>
+      <xsd:any namespace="##other" processContents="lax"
+              minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="Timestamp" type="xsd:dateTime" 
+               minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="Originator" type="wsa:EndpointReferenceType" 
+               minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ErrorCode" 
+               minOccurs="0" maxOccurs="1">
+        <xsd:complexType>
+          <xsd:complexContent mixed="true">
+            <xsd:extension base="xsd:anyType">
+              <xsd:attribute name="dialect" type="xsd:anyURI"
+                         use="required"/>
+            </xsd:extension>
+          </xsd:complexContent>
+        </xsd:complexType>      
+      </xsd:element>
+
+      <xsd:element name="Description" 
+               minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+              <xsd:attribute ref="xml:lang" use="optional"/>
+            </xsd:extension>
+          </xsd:simpleContent>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="FaultCause" minOccurs="0" maxOccurs="1">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:any namespace="##other" processContents="lax" 
+                     minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:complexType> 
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:anyAttribute namespace="##other" processContents="lax"/>
+ </xsd:complexType>
+</xsd:schema>

--- a/xsd_external/include.xsd
+++ b/xsd_external/include.xsd
@@ -1,0 +1,13 @@
+<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' 
+           xmlns:tns='http://www.w3.org/2004/08/xop/include' 
+           targetNamespace='http://www.w3.org/2004/08/xop/include' >
+
+  <xs:element name='Include' type='tns:Include' />
+  <xs:complexType name='Include' >
+	<xs:sequence>
+	  <xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded' />
+	</xs:sequence>
+	<xs:attribute name='href' type='xs:anyURI' use='required' />
+	<xs:anyAttribute namespace='##other' />
+  </xs:complexType>
+</xs:schema>

--- a/xsd_external/soap-envelope.xsd
+++ b/xsd_external/soap-envelope.xsd
@@ -1,0 +1,146 @@
+<!-- Schema defined in the SOAP Version 1.2 Part 1 specification
+     Recommendation:
+     http://www.w3.org/TR/2003/REC-soap12-part1-20030624/
+     $Id: soap-envelope.xsd,v 1.2 2006/12/20 20:43:36 ylafon Exp $
+
+     Copyright (C)2003 W3C(R) (MIT, ERCIM, Keio), All Rights Reserved.
+     W3C viability, trademark, document use and software licensing rules
+     apply.
+     http://www.w3.org/Consortium/Legal/
+
+     This document is governed by the W3C Software License [1] as
+     described in the FAQ [2].
+
+     [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+     [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.w3.org/2003/05/soap-envelope" targetNamespace="http://www.w3.org/2003/05/soap-envelope" elementFormDefault="qualified">
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+  <!-- Envelope, header and body -->
+  <xs:element name="Envelope" type="tns:Envelope"/>
+  <xs:complexType name="Envelope">
+    <xs:sequence>
+      <xs:element ref="tns:Header" minOccurs="0"/>
+      <xs:element ref="tns:Body" minOccurs="1"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:element name="Header" type="tns:Header"/>
+  <xs:complexType name="Header">
+    <xs:annotation>
+	  <xs:documentation>
+	  Elements replacing the wildcard MUST be namespace qualified, but can be in the targetNamespace
+	  </xs:documentation>
+	</xs:annotation>
+    <xs:sequence>
+      <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+  
+  <xs:element name="Body" type="tns:Body"/>
+  <xs:complexType name="Body">
+    <xs:sequence>
+      <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <!-- Global Attributes.  The following attributes are intended to be
+  usable via qualified attribute names on any complex type referencing
+  them.  -->
+  <xs:attribute name="mustUnderstand" type="xs:boolean" default="0"/>
+  <xs:attribute name="relay" type="xs:boolean" default="0"/>
+  <xs:attribute name="role" type="xs:anyURI"/>
+
+  <!-- 'encodingStyle' indicates any canonicalization conventions
+  followed in the contents of the containing element.  For example, the
+  value 'http://www.w3.org/2003/05/soap-encoding' indicates the pattern
+  described in the SOAP Version 1.2 Part 2: Adjuncts Recommendation -->
+
+  <xs:attribute name="encodingStyle" type="xs:anyURI"/>
+
+  <xs:element name="Fault" type="tns:Fault"/>
+  <xs:complexType name="Fault" final="extension">
+    <xs:annotation>
+	  <xs:documentation>
+	    Fault reporting structure
+	  </xs:documentation>
+	</xs:annotation>
+    <xs:sequence>
+      <xs:element name="Code" type="tns:faultcode"/>
+      <xs:element name="Reason" type="tns:faultreason"/>
+      <xs:element name="Node" type="xs:anyURI" minOccurs="0"/>
+	  <xs:element name="Role" type="xs:anyURI" minOccurs="0"/>
+      <xs:element name="Detail" type="tns:detail" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="faultreason">
+    <xs:sequence>
+	  <xs:element name="Text" type="tns:reasontext" minOccurs="1" maxOccurs="unbounded"/>
+	</xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="reasontext">
+    <xs:simpleContent>
+	  <xs:extension base="xs:string">
+	    <xs:attribute ref="xml:lang" use="required"/>
+	  </xs:extension>
+	</xs:simpleContent>
+  </xs:complexType>
+  
+  <xs:complexType name="faultcode">
+    <xs:sequence>
+      <xs:element name="Value" type="tns:faultcodeEnum"/>
+      <xs:element name="Subcode" type="tns:subcode" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="faultcodeEnum">
+    <xs:restriction base="xs:QName">
+      <xs:enumeration value="tns:DataEncodingUnknown"/>
+      <xs:enumeration value="tns:MustUnderstand"/>
+      <xs:enumeration value="tns:Receiver"/>
+      <xs:enumeration value="tns:Sender"/>
+      <xs:enumeration value="tns:VersionMismatch"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="subcode">
+    <xs:sequence>
+      <xs:element name="Value" type="xs:QName"/>
+      <xs:element name="Subcode" type="tns:subcode" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="detail">
+    <xs:sequence>
+      <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/> 
+  </xs:complexType>
+
+  <!-- Global element declaration and complex type definition for header entry returned due to a mustUnderstand fault -->
+  <xs:element name="NotUnderstood" type="tns:NotUnderstoodType"/>
+  <xs:complexType name="NotUnderstoodType">
+    <xs:attribute name="qname" type="xs:QName" use="required"/>
+  </xs:complexType>
+
+
+  <!-- Global element and associated types for managing version transition as described in Appendix A of the SOAP Version 1.2 Part 1 Recommendation  -->  <xs:complexType name="SupportedEnvType">
+    <xs:attribute name="qname" type="xs:QName" use="required"/>
+  </xs:complexType>
+
+  <xs:element name="Upgrade" type="tns:UpgradeType"/>
+  <xs:complexType name="UpgradeType">
+    <xs:sequence>
+	  <xs:element name="SupportedEnvelope" type="tns:SupportedEnvType" minOccurs="1" maxOccurs="unbounded"/>
+	</xs:sequence>
+  </xs:complexType>
+
+
+</xs:schema>

--- a/xsd_external/t-1.xsd
+++ b/xsd_external/t-1.xsd
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+
+OASIS takes no position regarding the validity or scope of any intellectual property or other rights that might be claimed to pertain to the implementation or use of the technology described in this document or the extent to which any license under such rights might or might not be available; neither does it represent that it has made any effort to identify any such rights. Information on OASIS's procedures with respect to rights in OASIS specifications can be found at the OASIS website. Copies of claims of rights made available for publication and any assurances of licenses to be made available, or the result of an attempt made to obtain a general license or permission for the use of such proprietary rights by implementors or users of this specification, can be obtained from the OASIS Executive Director.
+
+OASIS invites any interested party to bring to its attention any copyrights, patents or patent applications, or other proprietary rights which may cover technology that may be required to implement this specification. Please address the information to the OASIS Executive Director.
+
+Copyright (C) OASIS Open (2004-2006). All Rights Reserved.
+
+This document and translations of it may be copied and furnished to others, and derivative works that comment on or otherwise explain it or assist in its implementation may be prepared, copied, published and distributed, in whole or in part, without restriction of any kind, provided that the above copyright notice and this paragraph are included on all such copies and derivative works. However, this document itself may not be modified in any way, such as by removing the copyright notice or references to OASIS, except as needed for the purpose of developing OASIS specifications, in which case the procedures for copyrights defined in the OASIS Intellectual Property Rights document must be followed, or as required to translate it into languages other than English. 
+
+The limited permissions granted above are perpetual and will not be revoked by OASIS or its successors or assigns. 
+
+This document and the information contained herein is provided on an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+-->
+
+
+<xsd:schema 
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+  xmlns:wstop = "http://docs.oasis-open.org/wsn/t-1"
+  targetNamespace = "http://docs.oasis-open.org/wsn/t-1"   
+  elementFormDefault="qualified"  attributeFormDefault="unqualified">
+
+<!-- =============== utility type definitions  ==================== -->
+  <xsd:complexType name="Documentation" mixed="true">
+    <xsd:sequence>
+      <xsd:any processContents="lax" minOccurs="0" 
+               maxOccurs="unbounded" namespace="##any"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="ExtensibleDocumented" abstract="true" 
+                   mixed="false">
+    <xsd:sequence>
+      <xsd:element name="documentation" type="wstop:Documentation" 
+                   minOccurs="0" />
+    </xsd:sequence>
+    <xsd:anyAttribute namespace="##other" processContents="lax" />
+</xsd:complexType>
+
+<xsd:complexType name="QueryExpressionType" mixed="true">
+  <xsd:sequence>
+    <xsd:any minOccurs="0" maxOccurs="1" processContents="lax" />
+  </xsd:sequence>
+  <xsd:attribute name="Dialect" type="xsd:anyURI" use="required"/>
+</xsd:complexType>
+
+<!-- ================== Topic-Namespace Related  ================ -->   
+  <xsd:complexType name="TopicNamespaceType">
+    <xsd:complexContent>
+       <xsd:extension base="wstop:ExtensibleDocumented">
+         <xsd:sequence>
+           <xsd:element name="Topic" 
+                        minOccurs="0" maxOccurs="unbounded">
+              <xsd:complexType>
+              	<xsd:complexContent>
+              	  <xsd:extension base="wstop:TopicType">
+              	    <xsd:attribute name="parent" type="wstop:ConcreteTopicExpression" />
+              	  </xsd:extension>
+              	</xsd:complexContent>
+              </xsd:complexType>
+           </xsd:element>   
+           <xsd:any namespace="##other" 
+                    minOccurs="0" maxOccurs="unbounded" 
+                    processContents="lax"/>
+         </xsd:sequence>
+         <xsd:attribute name="name" type="xsd:NCName"/>
+         <xsd:attribute name="targetNamespace" type="xsd:anyURI" 
+                        use="required"/>
+         <xsd:attribute name="final" type="xsd:boolean" 
+                                     default="false"/>
+       </xsd:extension>
+     </xsd:complexContent> 
+   </xsd:complexType>
+
+  <xsd:element name="TopicNamespace" type="wstop:TopicNamespaceType">
+    <xsd:unique name="rootTopicUniqueness">
+      <xsd:selector xpath="wstop:Topic"/>
+        <xsd:field xpath="@name"/>
+    </xsd:unique>
+  </xsd:element>
+  
+  <xsd:attribute name="topicNamespaceLocation" type="xsd:anyURI"/>
+
+
+
+<!-- ===================== Topic Related  ========================= -->   
+
+  <xsd:complexType name="TopicType">
+    <xsd:complexContent>
+      <xsd:extension base="wstop:ExtensibleDocumented">
+        <xsd:sequence>
+          <xsd:element name="MessagePattern" 
+                       type="wstop:QueryExpressionType" 
+                       minOccurs="0" maxOccurs="1" />
+          <xsd:element name="Topic" type="wstop:TopicType" 
+                       minOccurs="0" maxOccurs="unbounded">
+            <xsd:unique name="childTopicUniqueness">
+              <xsd:selector xpath="wstop:topic"/>
+              <xsd:field xpath="@name"/>
+            </xsd:unique>
+          </xsd:element>
+          <xsd:any namespace="##other" minOccurs="0" 
+                                       maxOccurs="unbounded"/>
+        </xsd:sequence>
+        <xsd:attribute name="name" use="required" type="xsd:NCName"/>
+        <xsd:attribute name="messageTypes">
+          <xsd:simpleType>
+            <xsd:list itemType="xsd:QName"/>
+          </xsd:simpleType>
+        </xsd:attribute>
+        <xsd:attribute name="final" type="xsd:boolean" 
+                                     default="false"/>
+      </xsd:extension>
+    </xsd:complexContent>  
+  </xsd:complexType>
+
+<!-- ================ Topic Set Related  =================== -->   
+  
+  <xsd:complexType name="TopicSetType">
+    <xsd:complexContent>
+       <xsd:extension base="wstop:ExtensibleDocumented">
+         <xsd:sequence>
+           <xsd:any namespace="##other" 
+                    minOccurs="0" maxOccurs="unbounded" 
+                    processContents="lax"/>
+         </xsd:sequence>
+       </xsd:extension>
+     </xsd:complexContent> 
+   </xsd:complexType>
+
+  <xsd:element name="TopicSet" type="wstop:TopicSetType"/>
+<xsd:attribute name="topic" type="xsd:boolean" default="false"/>
+
+<!-- ================ Topic Expression Related  =================== -->   
+  
+  <xsd:simpleType name="FullTopicExpression">
+    <xsd:restriction base="xsd:token">
+      <xsd:annotation>
+        <xsd:documentation>
+        TopicPathExpression  ::=   TopicPath ( '|' TopicPath )*  
+        TopicPath       ::=   RootTopic ChildTopicExpression* 
+        RootTopic       ::=   NamespacePrefix? ('//')? (NCName | '*')  
+        NamespacePrefix ::=   NCName ':'      
+        ChildTopicExpression ::=   '/' '/'? (QName | NCName | '*'| '.')
+                        
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:pattern value= 
+         "([\i-[:]][\c-[:]]*:)?(//)?([\i-[:]][\c-[:]]*|\*)((/|//)(([\i-[:]][\c-[:]]*:)?[\i-[:]][\c-[:]]*|\*|[.]))*(\|([\i-[:]][\c-[:]]*:)?(//)?([\i-[:]][\c-[:]]*|\*)((/|//)(([\i-[:]][\c-[:]]*:)?[\i-[:]][\c-[:]]*|\*|[.]))*)*">
+      </xsd:pattern>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="ConcreteTopicExpression">
+    <xsd:restriction base="xsd:token">
+      <xsd:annotation>
+        <xsd:documentation>
+  The pattern allows strings matching the following EBNF:
+    ConcreteTopicPath    ::=   RootTopic ChildTopic*    
+    RootTopic            ::=   QName  
+    ChildTopic           ::=   '/' (QName | NCName) 
+                        
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:pattern value=
+"(([\i-[:]][\c-[:]]*:)?[\i-[:]][\c-[:]]*)(/([\i-[:]][\c-[:]]*:)?[\i-[:]][\c-[:]]*)*" >
+      </xsd:pattern>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="SimpleTopicExpression">
+    <xsd:restriction base="xsd:QName">
+      <xsd:annotation>
+        <xsd:documentation>
+  The pattern allows strings matching the following EBNF:
+    RootTopic            ::=   QName  
+                        
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/xsd_external/ws-addr.xsd
+++ b/xsd_external/ws-addr.xsd
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    W3C XML Schema defined in the Web Services Addressing 1.0 specification
+    http://www.w3.org/TR/ws-addr-core
+
+   Copyright © 2005 World Wide Web Consortium,
+
+   (Massachusetts Institute of Technology, European Research Consortium for
+   Informatics and Mathematics, Keio University). All Rights Reserved. This
+   work is distributed under the W3C® Software License [1] in the hope that
+   it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+   [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+
+   $Id: ws-addr.xsd,v 1.2 2008/07/23 13:38:16 plehegar Exp $
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.w3.org/2005/08/addressing" targetNamespace="http://www.w3.org/2005/08/addressing" blockDefault="#all" elementFormDefault="qualified" finalDefault="" attributeFormDefault="unqualified">
+	
+	<!-- Constructs from the WS-Addressing Core -->
+
+	<xs:element name="EndpointReference" type="tns:EndpointReferenceType"/>
+	<xs:complexType name="EndpointReferenceType" mixed="false">
+		<xs:sequence>
+			<xs:element name="Address" type="tns:AttributedURIType"/>
+			<xs:element ref="tns:ReferenceParameters" minOccurs="0"/>
+			<xs:element ref="tns:Metadata" minOccurs="0"/>
+			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+	<xs:element name="ReferenceParameters" type="tns:ReferenceParametersType"/>
+	<xs:complexType name="ReferenceParametersType" mixed="false">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+	<xs:element name="Metadata" type="tns:MetadataType"/>
+	<xs:complexType name="MetadataType" mixed="false">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+	<xs:element name="MessageID" type="tns:AttributedURIType"/>
+	<xs:element name="RelatesTo" type="tns:RelatesToType"/>
+	<xs:complexType name="RelatesToType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:anyURI">
+				<xs:attribute name="RelationshipType" type="tns:RelationshipTypeOpenEnum" use="optional" default="http://www.w3.org/2005/08/addressing/reply"/>
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<xs:simpleType name="RelationshipTypeOpenEnum">
+		<xs:union memberTypes="tns:RelationshipType xs:anyURI"/>
+	</xs:simpleType>
+	
+	<xs:simpleType name="RelationshipType">
+		<xs:restriction base="xs:anyURI">
+			<xs:enumeration value="http://www.w3.org/2005/08/addressing/reply"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
+	<xs:element name="ReplyTo" type="tns:EndpointReferenceType"/>
+	<xs:element name="From" type="tns:EndpointReferenceType"/>
+	<xs:element name="FaultTo" type="tns:EndpointReferenceType"/>
+	<xs:element name="To" type="tns:AttributedURIType"/>
+	<xs:element name="Action" type="tns:AttributedURIType"/>
+
+	<xs:complexType name="AttributedURIType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:anyURI">
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<!-- Constructs from the WS-Addressing SOAP binding -->
+
+	<xs:attribute name="IsReferenceParameter" type="xs:boolean"/>
+	
+	<xs:simpleType name="FaultCodesOpenEnumType">
+		<xs:union memberTypes="tns:FaultCodesType xs:QName"/>
+	</xs:simpleType>
+	
+	<xs:simpleType name="FaultCodesType">
+		<xs:restriction base="xs:QName">
+			<xs:enumeration value="tns:InvalidAddressingHeader"/>
+			<xs:enumeration value="tns:InvalidAddress"/>
+			<xs:enumeration value="tns:InvalidEPR"/>
+			<xs:enumeration value="tns:InvalidCardinality"/>
+			<xs:enumeration value="tns:MissingAddressInEPR"/>
+			<xs:enumeration value="tns:DuplicateMessageID"/>
+			<xs:enumeration value="tns:ActionMismatch"/>
+			<xs:enumeration value="tns:MessageAddressingHeaderRequired"/>
+			<xs:enumeration value="tns:DestinationUnreachable"/>
+			<xs:enumeration value="tns:ActionNotSupported"/>
+			<xs:enumeration value="tns:EndpointUnavailable"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
+	<xs:element name="RetryAfter" type="tns:AttributedUnsignedLongType"/>
+	<xs:complexType name="AttributedUnsignedLongType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:unsignedLong">
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<xs:element name="ProblemHeaderQName" type="tns:AttributedQNameType"/>
+	<xs:complexType name="AttributedQNameType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:QName">
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<xs:element name="ProblemIRI" type="tns:AttributedURIType"/>
+	
+	<xs:element name="ProblemAction" type="tns:ProblemActionType"/>
+	<xs:complexType name="ProblemActionType" mixed="false">
+		<xs:sequence>
+			<xs:element ref="tns:Action" minOccurs="0"/>
+			<xs:element name="SoapAction" minOccurs="0" type="xs:anyURI"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+</xs:schema>

--- a/xsd_external/ws-discovery.xsd
+++ b/xsd_external/ws-discovery.xsd
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Copyright Notice
+
+(c) 2004-2005 Microsoft Corporation, Inc. All rights reserved.
+
+Permission to copy, display, perform, modify and distribute the 
+WS-Discovery Specification (the "Specification", which includes 
+WSDL and schema documents), and to authorize others to do the 
+foregoing, in any medium without fee or royalty is hereby granted 
+for the purpose of developing and evaluating the Specification.
+
+BEA Systems, Canon, Intel, Microsoft, and webMethods, Inc. 
+(collectively, the "Co-Developers") each agree to grant a license 
+to third parties, under royalty-free and other reasonable, 
+non-discriminatory terms and conditions, to their respective 
+essential Licensed Claims, which reasonable, non-discriminatory 
+terms and conditions may include, for example, but are not limited 
+to, an affirmation  of the obligation to grant reciprocal licenses 
+under any of the licensee's patents that are necessary to implement 
+the Specification.  
+
+DISCLAIMERS:
+
+THE SPECIFICATION IS PROVIDED "AS IS," AND THE CO-DEVELOPERS MAKE 
+NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, 
+BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS 
+OF THE SPECIFICATION ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE 
+IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY 
+PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+THE CO-DEVELOPERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, 
+SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY 
+USE OF THE SPECIFICATION OR THE PERFORMANCE OR IMPLEMENTATION OF 
+THE CONTENTS THEREOF.
+
+You may remove these disclaimers from your modified versions of the 
+Specification provided that you effectively disclaim all warranties 
+and liabilities on behalf of all Co-developers and any copyright 
+holders in the copies of any such modified versions you distribute.
+
+The name and trademarks of the Co-developers may NOT be used in any 
+manner, including advertising or publicity pertaining to the 
+Specification or its contents without specific, written prior 
+permission. Title to copyright in the Specification will at all 
+times remain with Microsoft.
+
+No other rights are granted by implication, estoppel or otherwise.
+
+-->
+<xs:schema targetNamespace="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:tns="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" blockDefault="#all">
+
+  <xs:import namespace="http://schemas.xmlsoap.org/ws/2004/08/addressing" schemaLocation="http://schemas.xmlsoap.org/ws/2004/08/addressing"/>
+
+  <!-- //////////////////// Discovery Messages //////////////////// -->
+
+  <xs:element name="Hello" type="tns:HelloType"/>
+  <xs:complexType name="HelloType">
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference"/>
+      <xs:element ref="tns:Types" minOccurs="0"/>
+      <xs:element ref="tns:Scopes" minOccurs="0"/>
+      <xs:element ref="tns:XAddrs" minOccurs="0"/>
+      <xs:element ref="tns:MetadataVersion"/>
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:simpleType name="RelationshipType">
+	<xs:restriction base="xs:QName">
+	  <xs:enumeration value="tns:Suppression"/>
+	</xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="OpenRelationshipType">
+    <xs:union memberTypes="tns:RelationshipType xs:QName"/>
+  </xs:simpleType>
+    
+  <xs:element name="Bye" type="tns:ByeType"/>
+  <xs:complexType name="ByeType">
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference"/>
+      <xs:element ref="tns:Types" minOccurs="0"/>
+      <xs:element ref="tns:Scopes" minOccurs="0"/>
+      <xs:element ref="tns:XAddrs" minOccurs="0"/>
+      <xs:element ref="tns:MetadataVersion" minOccurs="0"/>
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:element name="Probe" type="tns:ProbeType"/>
+  <xs:complexType name="ProbeType">
+    <xs:sequence>
+      <xs:element ref="tns:Types" minOccurs="0"/>
+      <xs:element ref="tns:Scopes" minOccurs="0"/>
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:element name="ProbeMatches" type="tns:ProbeMatchesType"/>
+  <xs:complexType name="ProbeMatchesType">
+    <xs:sequence>
+      <xs:element name="ProbeMatch" type="tns:ProbeMatchType" minOccurs="0" maxOccurs="unbounded">
+      </xs:element>
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+  <xs:complexType name="ProbeMatchType">
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference"/>
+      <xs:element ref="tns:Types" minOccurs="0"/>
+      <xs:element ref="tns:Scopes" minOccurs="0"/>
+      <xs:element ref="tns:XAddrs" minOccurs="0"/>
+      <xs:element ref="tns:MetadataVersion"/>
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:element name="Resolve" type="tns:ResolveType"/>
+  <xs:complexType name="ResolveType">
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference"/>
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:element name="ResolveMatches" type="tns:ResolveMatchesType"/>
+  <xs:complexType name="ResolveMatchesType">
+    <xs:sequence>
+      <xs:element name="ResolveMatch" type="tns:ResolveMatchType" minOccurs="0"/>
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+  <xs:complexType name="ResolveMatchType">
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference"/>
+      <xs:element ref="tns:Types" minOccurs="0"/>
+      <xs:element ref="tns:Scopes" minOccurs="0"/>
+      <xs:element ref="tns:XAddrs"/>
+      <xs:element ref="tns:MetadataVersion"/>
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:element name="Types" type="tns:QNameListType"/>
+  <xs:simpleType name="QNameListType">
+    <xs:list itemType="xs:QName"/>
+  </xs:simpleType>
+
+  <xs:element name="Scopes" type="tns:ScopesType"/>
+  <xs:complexType name="ScopesType">
+    <xs:simpleContent>
+      <xs:extension base="tns:UriListType">
+        <xs:attribute name="MatchBy" type="xs:anyURI"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="XAddrs" type="tns:UriListType"/>
+  <xs:simpleType name="UriListType">
+    <xs:list itemType="xs:anyURI"/>
+  </xs:simpleType>
+
+  <xs:element name="MetadataVersion" type="xs:unsignedInt"/>
+
+  <!-- //////////////////// Faults //////////////////// -->
+
+  <xs:simpleType name="FaultCodeType">
+	<xs:restriction base="xs:QName">
+	  <xs:enumeration value="tns:MatchingRuleNotSupported"/>
+	</xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FaultCodeOpenType">
+    <xs:union memberTypes="tns:FaultCodeType xs:QName"/>
+  </xs:simpleType>
+
+  <xs:element name="SupportedMatchingRules" type="tns:UriListType"/>
+
+  <!-- //////////////////// Compact Signature //////////////////// -->
+
+  <xs:attribute name="Id" type="xs:ID"/>
+
+  <xs:element name="Security" type="tns:SecurityType"/>
+  <xs:complexType name="SecurityType">
+    <xs:sequence>
+      <xs:element ref="tns:Sig" minOccurs="0"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType> 
+
+  <xs:element name="Sig" type="tns:SigType"/>
+  <xs:complexType name="SigType">
+    <xs:sequence>
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="Scheme" type="xs:anyURI" use="required"/>
+    <xs:attribute name="KeyId" type="xs:base64Binary"/>
+    <xs:attribute name="Refs" type="xs:IDREFS" use="required"/>
+    <xs:attribute name="Sig" type="xs:base64Binary" use="required"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType> 
+
+  <!-- //////////////////// General Headers //////////////////// -->
+
+  <xs:element name="AppSequence" type="tns:AppSequenceType"/>
+  <xs:complexType name="AppSequenceType">
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="InstanceId" type="xs:unsignedInt" use="required"/>
+        <xs:attribute name="SequenceId" type="xs:anyURI"/>
+        <xs:attribute name="MessageNumber" type="xs:unsignedInt" use="required"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+</xs:schema>

--- a/xsd_external/xmlmime.xsd
+++ b/xsd_external/xmlmime.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<!-- 
+   W3C XML Schema defined in the Describing Media Content of Binary Data in XML
+   specification
+     http://www.w3.org/TR/xml-media-types
+
+   Copyright © 2005 World Wide Web Consortium,
+  
+   (Massachusetts Institute of Technology, European Research Consortium for
+   Informatics and Mathematics, Keio University). All Rights Reserved. This
+   work is distributed under the W3C® Software License [1] in the hope that
+   it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  
+   [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+
+   $Id: xmlmime.xsd,v 1.1 2005/04/25 17:08:35 hugo Exp $
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xmime="http://www.w3.org/2005/05/xmlmime"
+           targetNamespace="http://www.w3.org/2005/05/xmlmime" >
+
+  <xs:attribute name="contentType">
+    <xs:simpleType>
+      <xs:restriction base="xs:string" >
+      <xs:minLength value="3" />
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+
+  <xs:attribute name="expectedContentTypes" type="xs:string" />
+
+  <xs:complexType name="base64Binary" >
+    <xs:simpleContent>
+        <xs:extension base="xs:base64Binary" >
+            <xs:attribute ref="xmime:contentType" />
+        </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="hexBinary" >
+    <xs:simpleContent>
+        <xs:extension base="xs:hexBinary" >
+            <xs:attribute ref="xmime:contentType" />
+        </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
```
<xsd:simpleType name="AbsoluteOrRelativeTimeType">
  <xsd:union memberTypes="xsd:dateTime xsd:duration" />
</xsd:simpleType>
```
```
#[derive(PartialEq, Debug, YaSerialize, YaDeserialize)]
pub enum AbsoluteOrRelativeTimeType {
    #[yaserde(prefix = "xsd", rename = "dateTime")]
    DateTime(xsd::DateTime),
    #[yaserde(prefix = "xsd", rename = "duration")]
    Duration(xsd::Duration),
    __Unknown__(String)
}
```