### PR TITLE
Issue 59 - complex content restriction for ONVIF

### DIFF
--- a/xsd-parser-rs/src/parser/extension.rs
+++ b/xsd-parser-rs/src/parser/extension.rs
@@ -1,17 +1,17 @@
 use crate::parser::constants::{attribute, tag};
 use crate::parser::node_parser::parse_node;
 use crate::parser::types::{RsEntity, Struct, StructField, StructFieldSource};
-use crate::parser::utils::{attributes_to_fields, get_documentation};
+use crate::parser::utils::{attributes_to_fields, get_base, get_documentation};
 use crate::parser::xsd_elements::{ElementType, ExtensionType, XsdNode};
 use roxmltree::Node;
 use std::cell::RefCell;
 
 const AVAILABLE_CONTENT_TYPES: [ElementType; 6] = [
-    ElementType::All, //No in ONVIF
+    ElementType::All, // Not presented in ONVIF
     ElementType::Attribute,
     ElementType::AttributeGroup,
     ElementType::Choice,
-    ElementType::Group, //No in ONVIF
+    ElementType::Group, // Not presented in ONVIF
     ElementType::Sequence,
 ];
 
@@ -25,10 +25,7 @@ pub fn parse_extension(node: &Node, _: &Node) -> RsEntity {
 }
 
 fn simple_content_extension(node: &Node) -> RsEntity {
-    let base = node
-        .attribute(attribute::BASE)
-        .expect("The base value is required");
-
+    let base = get_base(node);
     let mut fields = attributes_to_fields(node);
 
     fields.push(StructField {

--- a/xsd-parser-rs/src/parser/tests.rs
+++ b/xsd-parser-rs/src/parser/tests.rs
@@ -63,4 +63,65 @@ mod test {
             _ => unreachable!(),
         }
     }
+
+    #[test]
+    fn test_restriction_any_type() {
+        use crate::parser::parse;
+        use crate::parser::types::RsEntity;
+
+        let text = r#"
+<xs:schema targetNamespace="http://schemas.xmlsoap.org/ws/2005/04/discovery"
+    xmlns:tns="http://schemas.xmlsoap.org/ws/2005/04/discovery"
+    xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" blockDefault="\#all">
+
+    <xs:element name="AppSequence" type="tns:AppSequenceType"/>
+    <xs:complexType name="AppSequenceType">
+        <xs:complexContent>
+            <xs:restriction base="xs:anyType">
+                <xs:attribute name="InstanceId" type="xs:unsignedInt" use="required"/>
+                <xs:attribute name="SequenceId" type="xs:anyURI"/>
+                <xs:attribute name="MessageNumber" type="xs:unsignedInt" use="required"/>
+                <xs:anyAttribute namespace="\#\#other" processContents="lax"/>
+            </xs:restriction>
+        </xs:complexContent>
+    </xs:complexType>
+
+</xs:schema>
+        "#;
+
+        let result = parse(text).unwrap();
+        println!("{:?}", result);  // TODO: remove
+        assert_eq!(result.types.len(), 2);
+
+        match &result.types[0] {
+            RsEntity::Alias(s) => {
+                assert_eq!(s.name, "AppSequence");
+                assert_eq!(s.original, "tns:AppSequenceType");
+            }
+            _ => unreachable!(),
+        }
+
+        match &result.types[1] {
+            RsEntity::Struct(s) => {
+                assert_eq!(s.fields.borrow().len(), 4);
+
+                assert_eq!(s.fields.borrow()[0].name, "InstanceId");
+                assert_eq!(s.fields.borrow()[0].type_name, "xs:unsignedInt");
+
+                assert_eq!(s.fields.borrow()[1].name, "SequenceId");
+                assert_eq!(s.fields.borrow()[1].type_name, "xs:anyURI");
+                assert_eq!(s.fields.borrow()[1].type_modifiers[0], TypeModifier::Option);
+
+                assert_eq!(s.fields.borrow()[2].name, "MessageNumber");
+                assert_eq!(s.fields.borrow()[2].type_name, "xs:unsignedInt");
+
+                assert_eq!(s.fields.borrow()[3].name, "any_attribute");
+
+                assert_eq!(s.name, "AppSequenceType");
+            }
+            _ => unreachable!(),
+        }
+    }
 }

--- a/xsd-parser-rs/src/parser/tests.rs
+++ b/xsd-parser-rs/src/parser/tests.rs
@@ -92,7 +92,7 @@ mod test {
         "#;
 
         let result = parse(text).unwrap();
-        println!("{:?}", result);  // TODO: remove
+        println!("{:?}", result); // TODO: remove
         assert_eq!(result.types.len(), 2);
 
         match &result.types[0] {

--- a/xsd-parser-rs/src/parser/utils.rs
+++ b/xsd-parser-rs/src/parser/utils.rs
@@ -43,6 +43,11 @@ pub fn get_parent_name<'a>(node: &Node<'a, '_>) -> &'a str {
     }
 }
 
+pub fn get_base<'a>(node: &Node<'a, '_>) -> &'a str {
+    node.attribute(attribute::BASE)
+        .expect("The base value is required")
+}
+
 pub fn attributes_to_fields(node: &Node) -> Vec<StructField> {
     node.children()
         .filter(|n| {


### PR DESCRIPTION
Closes #59 

Solves problem for the `restriction` occuring in ONVIF (whick is mentioned in the issue), but not in general case.

To see generated code you could run
```
cargo build && target\debug\xsd-parser.exe -i xsd_external\ws-discovery.xsd
```
Alternately, you may check added unit test.