### PR TITLE
Abstract code types: Notation, TopLevelSimpleType subtypes

### DIFF
--- a/xsd-parser/src/abstract_code_model/annotation.rs
+++ b/xsd-parser/src/abstract_code_model/annotation.rs
@@ -1,0 +1,11 @@
+use crate::abstract_code_model::app_info::AppInfo;
+use crate::abstract_code_model::comment::Comment;
+use crate::abstract_code_model::id::Id;
+
+#[derive(Debug, Default)]
+pub struct Annotation<'a> {
+    pub app_infos: Vec<AppInfo<'a>>,
+    pub comment: Comment<'a>,
+    pub id: Id<'a>,
+    // TODO: Vendor specific attributes support.
+}

--- a/xsd-parser/src/abstract_code_model/any_uri.rs
+++ b/xsd-parser/src/abstract_code_model/any_uri.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Default)]
+pub struct AnyUri<'a>( pub &'a str );

--- a/xsd-parser/src/abstract_code_model/any_uri.rs
+++ b/xsd-parser/src/abstract_code_model/any_uri.rs
@@ -1,2 +1,2 @@
-#[derive(Debug, Default)]
-pub struct AnyUri<'a>( pub &'a str );
+#[derive(Debug, Default, PartialEq)]
+pub struct AnyUri<'a>(pub &'a str);

--- a/xsd-parser/src/abstract_code_model/app_info.rs
+++ b/xsd-parser/src/abstract_code_model/app_info.rs
@@ -1,0 +1,9 @@
+use crate::abstract_code_model::any_uri::AnyUri;
+
+#[derive(Debug, Default)]
+pub struct AppInfo<'a> {
+    pub text: Option<&'a str>,
+    pub source: Option<AnyUri<'a>>,
+    // TODO: Vendor specific elements support.
+    // TODO: Vendor specific attributes support.
+}

--- a/xsd-parser/src/abstract_code_model/comment.rs
+++ b/xsd-parser/src/abstract_code_model/comment.rs
@@ -1,4 +1,4 @@
-#[derive(Default, Debug)]
+#[derive(Debug, Default)]
 pub struct Comment<'a> {
     pub text: Option<&'a str>,
 }

--- a/xsd-parser/src/abstract_code_model/comment.rs
+++ b/xsd-parser/src/abstract_code_model/comment.rs
@@ -1,4 +1,4 @@
 #[derive(Debug, Default)]
 pub struct Comment<'a> {
-    pub text: Option<&'a str>,
+    pub text: Vec<&'a str>,
 }

--- a/xsd-parser/src/abstract_code_model/id.rs
+++ b/xsd-parser/src/abstract_code_model/id.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Default)]
+pub struct Id<'a> ( pub Option<&'a str> );

--- a/xsd-parser/src/abstract_code_model/id.rs
+++ b/xsd-parser/src/abstract_code_model/id.rs
@@ -1,2 +1,2 @@
 #[derive(Debug, Default)]
-pub struct Id<'a> ( pub Option<&'a str> );
+pub struct Id<'a>(pub Option<&'a str>);

--- a/xsd-parser/src/abstract_code_model/mod.rs
+++ b/xsd-parser/src/abstract_code_model/mod.rs
@@ -1,4 +1,6 @@
+pub mod annotation;
 pub mod any_uri;
+pub mod app_info;
 pub mod comment;
 pub mod id;
 pub mod ncname;

--- a/xsd-parser/src/abstract_code_model/mod.rs
+++ b/xsd-parser/src/abstract_code_model/mod.rs
@@ -1,1 +1,4 @@
+pub mod any_uri;
 pub mod comment;
+pub mod id;
+pub mod ncname;

--- a/xsd-parser/src/abstract_code_model/mod.rs
+++ b/xsd-parser/src/abstract_code_model/mod.rs
@@ -4,3 +4,5 @@ pub mod app_info;
 pub mod comment;
 pub mod id;
 pub mod ncname;
+pub mod notation;
+pub mod public;

--- a/xsd-parser/src/abstract_code_model/ncname.rs
+++ b/xsd-parser/src/abstract_code_model/ncname.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Default)]
+pub struct NCName<'a>( pub &'a str );

--- a/xsd-parser/src/abstract_code_model/ncname.rs
+++ b/xsd-parser/src/abstract_code_model/ncname.rs
@@ -1,2 +1,2 @@
 #[derive(Debug, Default)]
-pub struct NCName<'a>( pub &'a str );
+pub struct NCName<'a>(pub &'a str);

--- a/xsd-parser/src/abstract_code_model/notation.rs
+++ b/xsd-parser/src/abstract_code_model/notation.rs
@@ -1,0 +1,15 @@
+use crate::abstract_code_model::annotation::Annotation;
+use crate::abstract_code_model::any_uri::AnyUri;
+use crate::abstract_code_model::id::Id;
+use crate::abstract_code_model::ncname::NCName;
+use crate::abstract_code_model::public::Public;
+
+#[derive(Debug, Default)]
+pub struct Notation<'a> {
+    pub annotation: Option<Annotation<'a>>,
+    pub id: Id<'a>,
+    pub name: NCName<'a>,
+    pub public: Option<Public<'a>>,
+    pub system: Option<AnyUri<'a>>,
+    // TODO: Vendor specific attributes support.
+}

--- a/xsd-parser/src/abstract_code_model/public.rs
+++ b/xsd-parser/src/abstract_code_model/public.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Default)]
+pub struct Public<'a>(pub &'a str);

--- a/xsd-parser/src/xml_to_xsd/complex_type_model.rs
+++ b/xsd-parser/src/xml_to_xsd/complex_type_model.rs
@@ -19,7 +19,12 @@ impl<'a> ComplexTypeModel<'a> {
 
         let first_child = match first_child {
             Some(x) => x,
-            None => return Ok(ComplexTypeModel::Content(None, Box::new(AttrDecls::default())))
+            None => {
+                return Ok(ComplexTypeModel::Content(
+                    None,
+                    Box::new(AttrDecls::default()),
+                ))
+            }
         };
 
         let type_def_particle;

--- a/xsd-parser/src/xsd_model/elements/notation.rs
+++ b/xsd-parser/src/xsd_model/elements/notation.rs
@@ -26,7 +26,7 @@ use crate::xsd_model::RawAttribute;
 // Used in
 // Group xsd:schemaTop
 // Anonymous type of element xsd:schema via reference to xsd:schemaTop
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Notation<'a> {
     pub annotation: Option<Annotation<'a>>,
     pub attributes: Vec<RawAttribute<'a>>,

--- a/xsd-parser/src/xsd_to_abstract_code/annotation.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/annotation.rs
@@ -1,0 +1,54 @@
+use crate::abstract_code_model::annotation::Annotation;
+use crate::abstract_code_model::app_info::AppInfo;
+use crate::abstract_code_model::comment::Comment;
+use crate::abstract_code_model::id::Id;
+use crate::xsd_model::elements::annotation::Annotation as XsdAnnotation;
+
+impl<'a> Annotation<'a> {
+    pub fn parse(annotation: &XsdAnnotation<'a>) -> Annotation<'a> {
+        Annotation {
+            app_infos: annotation
+                .app_infos
+                .iter()
+                .map(|x| AppInfo::parse(x))
+                .collect(),
+            comment: Comment::parse_vec(&annotation.documentations),
+            id: Id::parse(&annotation.id)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::abstract_code_model::annotation::Annotation;
+    use crate::xsd_model::elements::annotation::Annotation as XsdAnnotation;
+    use crate::xsd_model::elements::documentation::Documentation;
+    use crate::xsd_model::simple_types::id::Id as XsdId;
+
+    #[test]
+    fn test_annotation_parse() {
+        let annotation = XsdAnnotation {
+            app_infos: vec![Default::default(), Default::default(), Default::default()],
+            documentations: vec![
+                Documentation {
+                    text: Some("A string"),
+                    ..Default::default()
+                },
+                Documentation {
+                    text: None,
+                    ..Default::default()
+                },
+                Documentation {
+                    text: Some("Another string"),
+                    ..Default::default()
+                },
+            ],
+            id: Some(XsdId("An id")),
+            ..Default::default()
+        };
+        let res = Annotation::parse(&annotation);
+        assert_eq!(res.app_infos.len(), 3);
+        assert_eq!(res.comment.text.len(), 2);
+        assert_eq!(res.id.0, Some("An id"));
+    }
+}

--- a/xsd-parser/src/xsd_to_abstract_code/annotation.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/annotation.rs
@@ -13,7 +13,7 @@ impl<'a> Annotation<'a> {
                 .map(|x| AppInfo::parse(x))
                 .collect(),
             comment: Comment::parse_vec(&annotation.documentations),
-            id: Id::parse(&annotation.id)
+            id: Id::parse(&annotation.id),
         }
     }
 }

--- a/xsd-parser/src/xsd_to_abstract_code/any_uri.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/any_uri.rs
@@ -3,7 +3,7 @@ use crate::xsd_model::simple_types::any_uri::AnyUri as XsdAnyUri;
 
 impl<'a> AnyUri<'a> {
     pub fn parse(uri: &XsdAnyUri<'a>) -> AnyUri<'a> {
-        AnyUri( uri.0 )
+        AnyUri(uri.0)
     }
 }
 

--- a/xsd-parser/src/xsd_to_abstract_code/any_uri.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/any_uri.rs
@@ -1,0 +1,21 @@
+use crate::abstract_code_model::any_uri::AnyUri;
+use crate::xsd_model::simple_types::any_uri::AnyUri as XsdAnyUri;
+
+impl<'a> AnyUri<'a> {
+    pub fn parse(uri: &XsdAnyUri<'a>) -> AnyUri<'a> {
+        AnyUri( uri.0 )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::abstract_code_model::any_uri::AnyUri;
+    use crate::xsd_model::simple_types::any_uri::AnyUri as XsdAnyUri;
+
+    #[test]
+    fn test_any_uri_parse() {
+        let uri = XsdAnyUri("An URI");
+        let res = AnyUri::parse(&uri);
+        assert_eq!(res.0, "An URI");
+    }
+}

--- a/xsd-parser/src/xsd_to_abstract_code/app_info.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/app_info.rs
@@ -1,0 +1,32 @@
+use crate::abstract_code_model::any_uri::AnyUri;
+use crate::abstract_code_model::app_info::AppInfo;
+use crate::xsd_model::elements::app_info::AppInfo as XsdAppInfo;
+
+impl<'a> AppInfo<'a> {
+    pub fn parse(app_info: &XsdAppInfo<'a>) -> AppInfo<'a> {
+        AppInfo {
+            text: app_info.text,
+            source: app_info.source.as_ref().map(|x| AnyUri::parse(x)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::abstract_code_model::any_uri::AnyUri;
+    use crate::abstract_code_model::app_info::AppInfo;
+    use crate::xsd_model::elements::app_info::AppInfo as XsdAppInfo;
+    use crate::xsd_model::simple_types::any_uri::AnyUri as XsdAnyUri;
+
+    #[test]
+    fn test_app_info_parse() {
+        let app_info = XsdAppInfo {
+            text: Some("A string"),
+            source: Some(XsdAnyUri("An URI")),
+            ..Default::default()
+        };
+        let res = AppInfo::parse(&app_info);
+        assert_eq!(res.text.unwrap(), "A string");
+        assert_eq!(res.source.unwrap(), AnyUri("An URI"));
+    }
+}

--- a/xsd-parser/src/xsd_to_abstract_code/comment.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/comment.rs
@@ -2,10 +2,20 @@ use crate::abstract_code_model::comment::Comment;
 use crate::xsd_model::Documentation;
 
 impl<'a> Comment<'a> {
-    pub fn parse(doc: &Documentation<'a>) -> Result<Comment<'a>, String> {
-        let mut res = Comment::default();
-        res.text = doc.text;
-        Ok(res)
+    pub fn parse(doc: &Documentation<'a>) -> Comment<'a> {
+        Comment {
+            text: if let Some(text) = doc.text { vec![text] } else { Vec::new() }
+        }
+    }
+
+    pub fn parse_vec(docs: &[Documentation<'a>]) -> Comment<'a> {
+        Comment {
+            text: docs
+            .iter()
+            .filter(|x| x.text.is_some())
+            .map(|x| x.text.unwrap())
+            .collect()
+        }
     }
 }
 
@@ -20,7 +30,31 @@ mod test {
             text: Some("A string"),
             ..Default::default()
         };
-        let res = Comment::parse(&doc).unwrap();
-        assert_eq!(res.text.unwrap(), "A string");
+        let res = Comment::parse(&doc);
+        assert_eq!(res.text.len(), 1);
+        assert_eq!(res.text[0], "A string");
+    }
+
+    #[test]
+    fn test_comment_parse_vec() {
+        let docs = vec![
+            Documentation {
+                text: Some("A string"),
+                ..Default::default()
+            },
+            Documentation {
+                text: None,
+                ..Default::default()
+            },
+            Documentation {
+                text: Some("Another string"),
+                ..Default::default()
+            },
+        ];
+
+        let res = Comment::parse_vec(&docs);
+        assert_eq!(res.text.len(), 2);
+        assert_eq!(res.text[0], "A string");
+        assert_eq!(res.text[1], "Another string");
     }
 }

--- a/xsd-parser/src/xsd_to_abstract_code/comment.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/comment.rs
@@ -4,17 +4,21 @@ use crate::xsd_model::Documentation;
 impl<'a> Comment<'a> {
     pub fn parse(doc: &Documentation<'a>) -> Comment<'a> {
         Comment {
-            text: if let Some(text) = doc.text { vec![text] } else { Vec::new() }
+            text: if let Some(text) = doc.text {
+                vec![text]
+            } else {
+                Vec::new()
+            },
         }
     }
 
     pub fn parse_vec(docs: &[Documentation<'a>]) -> Comment<'a> {
         Comment {
             text: docs
-            .iter()
-            .filter(|x| x.text.is_some())
-            .map(|x| x.text.unwrap())
-            .collect()
+                .iter()
+                .filter(|x| x.text.is_some())
+                .map(|x| x.text.unwrap())
+                .collect(),
         }
     }
 }

--- a/xsd-parser/src/xsd_to_abstract_code/id.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/id.rs
@@ -1,0 +1,26 @@
+use crate::abstract_code_model::id::Id;
+use crate::xsd_model::simple_types::Id as OptionalXsdId;
+
+impl<'a> Id<'a> {
+    pub fn parse(id: &OptionalXsdId<'a>) -> Id<'a> {
+        if let Some(id) = id {
+            Id(Some(id.0))
+        } else {
+            Id(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::abstract_code_model::id::Id;
+    use crate::xsd_model::simple_types::Id as OptionalXsdId;
+    use crate::xsd_model::simple_types::id::Id as XsdId;
+
+    #[test]
+    fn test_id_parse() {
+        let id : OptionalXsdId = Some( XsdId("An id") );
+        let res = Id::parse(&id);
+        assert_eq!(res.0, Some("An id"));
+    }
+}

--- a/xsd-parser/src/xsd_to_abstract_code/id.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/id.rs
@@ -3,23 +3,19 @@ use crate::xsd_model::simple_types::Id as OptionalXsdId;
 
 impl<'a> Id<'a> {
     pub fn parse(id: &OptionalXsdId<'a>) -> Id<'a> {
-        if let Some(id) = id {
-            Id(Some(id.0))
-        } else {
-            Id(None)
-        }
+        Id(id.as_ref().map(|x| x.0))
     }
 }
 
 #[cfg(test)]
 mod test {
     use crate::abstract_code_model::id::Id;
-    use crate::xsd_model::simple_types::Id as OptionalXsdId;
     use crate::xsd_model::simple_types::id::Id as XsdId;
+    use crate::xsd_model::simple_types::Id as OptionalXsdId;
 
     #[test]
     fn test_id_parse() {
-        let id : OptionalXsdId = Some( XsdId("An id") );
+        let id: OptionalXsdId = Some(XsdId("An id"));
         let res = Id::parse(&id);
         assert_eq!(res.0, Some("An id"));
     }

--- a/xsd-parser/src/xsd_to_abstract_code/mod.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/mod.rs
@@ -1,4 +1,6 @@
+pub mod annotation;
 pub mod any_uri;
+pub mod app_info;
 pub mod comment;
 pub mod id;
 pub mod ncname;

--- a/xsd-parser/src/xsd_to_abstract_code/mod.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/mod.rs
@@ -1,1 +1,4 @@
+pub mod any_uri;
 pub mod comment;
+pub mod id;
+pub mod ncname;

--- a/xsd-parser/src/xsd_to_abstract_code/mod.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/mod.rs
@@ -4,3 +4,5 @@ pub mod app_info;
 pub mod comment;
 pub mod id;
 pub mod ncname;
+pub mod notation;
+pub mod public;

--- a/xsd-parser/src/xsd_to_abstract_code/ncname.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/ncname.rs
@@ -3,7 +3,7 @@ use crate::xsd_model::simple_types::ncname::NCName as XsdNCName;
 
 impl<'a> NCName<'a> {
     pub fn parse(ncname: &XsdNCName<'a>) -> NCName<'a> {
-        NCName( ncname.0 )
+        NCName(ncname.0)
     }
 }
 

--- a/xsd-parser/src/xsd_to_abstract_code/ncname.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/ncname.rs
@@ -1,0 +1,21 @@
+use crate::abstract_code_model::ncname::NCName;
+use crate::xsd_model::simple_types::ncname::NCName as XsdNCName;
+
+impl<'a> NCName<'a> {
+    pub fn parse(ncname: &XsdNCName<'a>) -> NCName<'a> {
+        NCName( ncname.0 )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::abstract_code_model::ncname::NCName;
+    use crate::xsd_model::simple_types::ncname::NCName as XsdNCName;
+
+    #[test]
+    fn test_ncname_parse() {
+        let ncname = XsdNCName("A NCName");
+        let res = NCName::parse(&ncname);
+        assert_eq!(res.0, "A NCName");
+    }
+}

--- a/xsd-parser/src/xsd_to_abstract_code/notation.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/notation.rs
@@ -1,0 +1,47 @@
+use crate::abstract_code_model::annotation::Annotation;
+use crate::abstract_code_model::any_uri::AnyUri;
+use crate::abstract_code_model::id::Id;
+use crate::abstract_code_model::ncname::NCName;
+use crate::abstract_code_model::notation::Notation;
+use crate::abstract_code_model::public::Public;
+use crate::xsd_model::elements::notation::Notation as XsdNotation;
+
+impl<'a> Notation<'a> {
+    pub fn parse(notation: &XsdNotation<'a>) -> Notation<'a> {
+        Notation {
+            annotation: notation.annotation.as_ref().map(Annotation::parse),
+            id: Id::parse(&notation.id),
+            name: NCName::parse(&notation.name),
+            public: notation.public.as_ref().map(Public::parse),
+            system: notation.system.as_ref().map(AnyUri::parse),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::abstract_code_model::notation::Notation;
+    use crate::xsd_model::elements::notation::Notation as XsdNotation;
+    use crate::xsd_model::simple_types::any_uri::AnyUri as XsdAnyUri;
+    use crate::xsd_model::simple_types::id::Id as XsdId;
+    use crate::xsd_model::simple_types::ncname::NCName as XsdNCName;
+    use crate::xsd_model::simple_types::token::Token as XsdToken;
+
+    #[test]
+    fn test_notation_parse() {
+        let notation = XsdNotation {
+            annotation: Some(Default::default()),
+            id: Some(XsdId("An id")),
+            name: XsdNCName("A name"),
+            public: Some(XsdToken("Public")),
+            system: Some(XsdAnyUri("An URI")),
+            ..Default::default()
+        };
+        let res = Notation::parse(&notation);
+        assert!(res.annotation.is_some());
+        assert_eq!(res.id.0, Some("An id"));
+        assert_eq!(res.name.0, "A name");
+        assert_eq!(res.public.unwrap().0, "Public");
+        assert_eq!(res.system.unwrap().0, "An URI");
+    }
+}

--- a/xsd-parser/src/xsd_to_abstract_code/public.rs
+++ b/xsd-parser/src/xsd_to_abstract_code/public.rs
@@ -1,0 +1,21 @@
+use crate::abstract_code_model::public::Public;
+use crate::xsd_model::simple_types::public::Public as XsdPublic;
+
+impl<'a> Public<'a> {
+    pub fn parse(ncname: &XsdPublic<'a>) -> Public<'a> {
+        Public(ncname.0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::abstract_code_model::public::Public;
+    use crate::xsd_model::simple_types::token::Token;
+
+    #[test]
+    fn test_public_parse() {
+        let public = Token("Public");
+        let res = Public::parse(&public);
+        assert_eq!(res.0, "Public");
+    }
+}

--- a/xsd-types/src/types/decimal.rs
+++ b/xsd-types/src/types/decimal.rs
@@ -7,11 +7,11 @@ use std::str::FromStr;
 use yaserde::{YaDeserialize, YaSerialize};
 
 #[derive(Default, PartialEq, PartialOrd, Debug, UtilsDefaultSerde)]
-pub struct Decimal (pub BigDecimal);
+pub struct Decimal(pub BigDecimal);
 
 impl Decimal {
     pub fn from_bigdecimal(bigdecimal: BigDecimal) -> Self {
-        Decimal ( bigdecimal )
+        Decimal(bigdecimal)
     }
 
     pub fn to_bigdecimal(&self) -> BigDecimal {
@@ -23,7 +23,7 @@ impl FromStr for Decimal {
     type Err = ParseBigDecimalError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Decimal ( BigDecimal::from_str(s)?))
+        Ok(Decimal(BigDecimal::from_str(s)?))
     }
 }
 


### PR DESCRIPTION
Implemented TopLevelSimpleType subtypes (except SimpleDerivation, which can not be implemented without type resolver) and Notation type at abstract code level with converting functions for them.

Partially covers #98 