### PR TITLE
Update to yaserde 0.4 and implement rename on structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb76e5c421bbbeb8924c60c030331b345555024d56261dae8f3e786ed817c23"
+checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
 name = "xmlparser"
@@ -439,8 +454,9 @@ dependencies = [
 
 [[package]]
 name = "yaserde"
-version = "0.3.14"
-source = "git+https://github.com/media-io/yaserde?rev=137af01#137af01ad074ae14d6a000e99e75022ef19eda2b"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b662283bed00e1455f973849591a51a19771033f0cc081692486f216489c59"
 dependencies = [
  "log",
  "xml-rs",
@@ -448,9 +464,11 @@ dependencies = [
 
 [[package]]
 name = "yaserde_derive"
-version = "0.3.14"
-source = "git+https://github.com/media-io/yaserde?rev=137af01#137af01ad074ae14d6a000e99e75022ef19eda2b"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d4a64f5dcdf440f14d5cf6994899b44403aa0e98dcfc5943c21c543d850563"
 dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn",

--- a/macro-utils/src/lib.rs
+++ b/macro-utils/src/lib.rs
@@ -35,6 +35,10 @@ pub fn default_serde(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
             fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
                 utils::yaserde::serialize(self, #struct_name_literal, writer, |s| s.to_string())
             }
+
+            fn serialize_attributes(&self, attributes: Vec<xml::attribute::OwnedAttribute>, namespace: xml::namespace::Namespace) -> Result<(Vec<xml::attribute::OwnedAttribute>, xml::namespace::Namespace), String> {
+                Ok((attributes, namespace))
+            }
         }
 
         impl YaDeserialize for #struct_name {

--- a/macro-utils/src/lib.rs
+++ b/macro-utils/src/lib.rs
@@ -36,7 +36,10 @@ pub fn default_serde(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
                 utils::yaserde::serialize(self, #struct_name_literal, writer, |s| s.to_string())
             }
 
-            fn serialize_attributes(&self, attributes: Vec<xml::attribute::OwnedAttribute>, namespace: xml::namespace::Namespace) -> Result<(Vec<xml::attribute::OwnedAttribute>, xml::namespace::Namespace), String> {
+            fn serialize_attributes(&self,
+                                    attributes: Vec<xml::attribute::OwnedAttribute>,
+                                    namespace: xml::namespace::Namespace)
+                -> Result<(Vec<xml::attribute::OwnedAttribute>, xml::namespace::Namespace), String> {
                 Ok((attributes, namespace))
             }
         }

--- a/xsd-parser/Cargo.toml
+++ b/xsd-parser/Cargo.toml
@@ -24,8 +24,8 @@ clap = "2.33.0"
 syn = { version = "1.0", features = ["full"] }
 log = "0.4.8"
 xml-rs = "0.8.0"
-yaserde = { git = "https://github.com/media-io/yaserde", rev = "137af01" }
-yaserde_derive = { git = "https://github.com/media-io/yaserde", rev = "137af01" }
+yaserde = "0.4"
+yaserde_derive = "0.4"
 text-diff = "0.4.0"
 itertools = "0.8.1"
 macro-utils = { path = "../macro-utils" }

--- a/xsd-parser/src/generator/struct.rs
+++ b/xsd-parser/src/generator/struct.rs
@@ -90,15 +90,17 @@ pub trait StructGenerator {
         match tns.as_ref() {
             Some(tn) => match tn.name() {
                 Some(name) => format!(
-                    "{derives}#[yaserde(prefix = \"{prefix}\", namespace = \"{prefix}: {uri}\")]\n",
+                    "{derives}#[yaserde(prefix = \"{prefix}\", namespace = \"{prefix}: {uri}\", rename = \"{rename}\")]\n",
                     derives = derives,
                     prefix = name,
-                    uri = tn.uri()
+                    uri = tn.uri(),
+                    rename = _entity.name.as_str()
                 ),
                 None => format!(
-                    "{derives}#[yaserde(namespace = \"{uri}\")]\n",
+                    "{derives}#[yaserde(namespace = \"{uri}\", rename = \"{rename}\")]\n",
                     derives = derives,
-                    uri = tn.uri()
+                    uri = tn.uri(),
+                    rename = _entity.name.as_str()
                 ),
             },
             None => format!("{derives}#[yaserde()]\n", derives = derives),

--- a/xsd-types/Cargo.toml
+++ b/xsd-types/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 [dependencies]
 log = "0.4.8"
 xml-rs = "0.8.0"
-yaserde = { git = "https://github.com/media-io/yaserde", rev = "137af01" }
-yaserde_derive = { git = "https://github.com/media-io/yaserde", rev = "137af01" }
+yaserde = "0.4"
+yaserde_derive = "0.4"
 chrono = "0.4.10"
 itertools = "0.8.1"
 macro-utils = { path = "../macro-utils" }


### PR DESCRIPTION
* Update to yaserde 0.4.
* Implemented` serialize_attributes` method for YaSerialize in the UtilsDefaultSerde macro.
* Some SOAP services use lowerCamelCase names for the types (eg: `getRecordDataHeaders`) which is inadvertently converted to upperCamelCase (`GetRecordDataHeaders`) because of the struct name conversion. Use yaserde 0.4 support for `rename` in struct attributes to preserve the name from the XSD/WSDL.

This will require projects using this library to upgrade to yaserde 0.4. No code changes should be required if they do not manually implement `YaSerialize`.