### PR TITLE
Add support for AttributeGroup in xsd-parser

### DIFF
--- a/xsd-parser/src/parser/attribute_group.rs
+++ b/xsd-parser/src/parser/attribute_group.rs
@@ -1,0 +1,92 @@
+use roxmltree::Node;
+
+use crate::parser::node_parser::parse_node;
+use crate::parser::types::{Alias, RsEntity, Struct, StructField};
+use crate::parser::utils::get_documentation;
+use crate::parser::xsd_elements::{ElementType, XsdNode};
+
+pub fn parse_attribute_group(node: &Node, parent: &Node) -> RsEntity {
+    if parent.xsd_type() == ElementType::Schema {
+        return parse_global_attribute_group(node);
+    }
+
+    let reference = node
+        .attr_ref()
+        .expect("Non-global attributeGroups must be references.")
+        .to_string();
+
+    RsEntity::Alias(Alias {
+        name: reference.to_string(),
+        original: reference,
+        comment: get_documentation(node),
+        ..Default::default()
+    })
+}
+
+fn parse_global_attribute_group(node: &Node) -> RsEntity {
+    let name = node
+        .attr_name()
+        .unwrap_or_else(|| panic!("Name attribute required. {:?}", node));
+
+    let fields = attributes_to_fields(node);
+    
+    RsEntity::Struct(Struct {
+        name: name.to_string(),
+        fields: std::cell::RefCell::new(fields),
+        ..Default::default()
+    })
+}
+
+pub fn attributes_to_fields(node: &Node) -> Vec<StructField> {
+    node.children()
+        .filter(|n| {
+            n.xsd_type() == ElementType::Attribute || n.xsd_type() == ElementType::AnyAttribute
+        })
+        .map(|n| match parse_node(&n, node) {
+            RsEntity::StructField(sf) => sf,
+            _ => unreachable!("Invalid attribute parsing: {:?}", n),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use crate::parser::attribute_group::parse_global_attribute_group;
+    use crate::parser::types::RsEntity;
+    use crate::parser::utils::find_child;
+
+    #[test]
+    fn test_global_attribute_with_nested_type() {
+        let doc = roxmltree::Document::parse(
+            r#"
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xmime="http://www.w3.org/2005/05/xmlmime"
+           targetNamespace="http://www.w3.org/2005/05/xmlmime" >
+
+            <xs:attributeGroup name="contentGroup">
+                <xs:attribute name="restricted">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string" >
+                            <xs:minLength value="3" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="simple" type="xs:string" />
+            </xs:attributeGroup>
+        </xs:schema>
+        "#,
+        )
+        .unwrap();
+
+        let schema = doc.root_element();
+        let attribute = find_child(&schema, "attributeGroup").unwrap();
+        match parse_global_attribute_group(&attribute) {
+            RsEntity::Struct(ts) => {
+                assert_eq!(ts.name, "contentGroup");
+                assert_eq!(ts.fields.borrow().len(), 2);
+            }
+            _ => unreachable!("Test Failed!"),
+        }
+    }
+
+}

--- a/xsd-parser/src/parser/attribute_group.rs
+++ b/xsd-parser/src/parser/attribute_group.rs
@@ -29,7 +29,7 @@ fn parse_global_attribute_group(node: &Node) -> RsEntity {
         .unwrap_or_else(|| panic!("Name attribute required. {:?}", node));
 
     let fields = attributes_to_fields(node);
-    
+
     RsEntity::Struct(Struct {
         name: name.to_string(),
         fields: std::cell::RefCell::new(fields),
@@ -88,5 +88,4 @@ mod test {
             _ => unreachable!("Test Failed!"),
         }
     }
-
 }

--- a/xsd-parser/src/parser/complex_type.rs
+++ b/xsd-parser/src/parser/complex_type.rs
@@ -4,7 +4,9 @@ use roxmltree::Node;
 
 use crate::parser::node_parser::parse_node;
 use crate::parser::types::{RsEntity, Struct, StructField, StructFieldSource};
-use crate::parser::utils::{attributes_to_fields, attribute_groups_to_aliases, get_documentation, get_parent_name};
+use crate::parser::utils::{
+    attribute_groups_to_aliases, attributes_to_fields, get_documentation, get_parent_name,
+};
 use crate::parser::xsd_elements::{ElementType, XsdNode};
 
 // A complex type can contain one and only one of the following elements,

--- a/xsd-parser/src/parser/complex_type.rs
+++ b/xsd-parser/src/parser/complex_type.rs
@@ -4,7 +4,7 @@ use roxmltree::Node;
 
 use crate::parser::node_parser::parse_node;
 use crate::parser::types::{RsEntity, Struct, StructField, StructFieldSource};
-use crate::parser::utils::{attributes_to_fields, get_documentation, get_parent_name};
+use crate::parser::utils::{attributes_to_fields, attribute_groups_to_aliases, get_documentation, get_parent_name};
 use crate::parser::xsd_elements::{ElementType, XsdNode};
 
 // A complex type can contain one and only one of the following elements,
@@ -45,6 +45,7 @@ pub fn parse_complex_type(node: &Node, parent: &Node) -> RsEntity {
 
         return RsEntity::Struct(Struct {
             fields: RefCell::new(fields),
+            attribute_groups: RefCell::new(attribute_groups_to_aliases(node)),
             comment: get_documentation(node),
             subtypes: vec![],
             name: name.to_string(),
@@ -71,6 +72,7 @@ pub fn parse_complex_type(node: &Node, parent: &Node) -> RsEntity {
                 subtypes: vec![],
                 comment: get_documentation(node),
                 fields: RefCell::new(fields),
+                attribute_groups: RefCell::new(attribute_groups_to_aliases(node)),
             })];
         }
         _ => (),

--- a/xsd-parser/src/parser/extension.rs
+++ b/xsd-parser/src/parser/extension.rs
@@ -1,7 +1,7 @@
 use crate::parser::constants::{attribute, tag};
 use crate::parser::node_parser::parse_node;
 use crate::parser::types::{RsEntity, Struct, StructField, StructFieldSource};
-use crate::parser::utils::{attributes_to_fields, get_base, get_documentation};
+use crate::parser::utils::{attributes_to_fields, attribute_groups_to_aliases, get_base, get_documentation};
 use crate::parser::xsd_elements::{ElementType, ExtensionType, XsdNode};
 use roxmltree::Node;
 use std::cell::RefCell;
@@ -41,6 +41,7 @@ fn simple_content_extension(node: &Node) -> RsEntity {
         subtypes: vec![],
         comment: get_documentation(node),
         fields: RefCell::new(fields),
+        attribute_groups: RefCell::new(attribute_groups_to_aliases(node))
     })
 }
 
@@ -80,6 +81,7 @@ fn complex_content_extension(node: &Node) -> RsEntity {
     RsEntity::Struct(Struct {
         comment: get_documentation(node),
         fields: RefCell::new(fields),
+        attribute_groups: RefCell::new(attribute_groups_to_aliases(node)),
         ..Default::default()
     })
 }

--- a/xsd-parser/src/parser/extension.rs
+++ b/xsd-parser/src/parser/extension.rs
@@ -1,7 +1,9 @@
 use crate::parser::constants::{attribute, tag};
 use crate::parser::node_parser::parse_node;
 use crate::parser::types::{RsEntity, Struct, StructField, StructFieldSource};
-use crate::parser::utils::{attributes_to_fields, attribute_groups_to_aliases, get_base, get_documentation};
+use crate::parser::utils::{
+    attribute_groups_to_aliases, attributes_to_fields, get_base, get_documentation,
+};
 use crate::parser::xsd_elements::{ElementType, ExtensionType, XsdNode};
 use roxmltree::Node;
 use std::cell::RefCell;
@@ -41,7 +43,7 @@ fn simple_content_extension(node: &Node) -> RsEntity {
         subtypes: vec![],
         comment: get_documentation(node),
         fields: RefCell::new(fields),
-        attribute_groups: RefCell::new(attribute_groups_to_aliases(node))
+        attribute_groups: RefCell::new(attribute_groups_to_aliases(node)),
     })
 }
 

--- a/xsd-parser/src/parser/mod.rs
+++ b/xsd-parser/src/parser/mod.rs
@@ -1,6 +1,7 @@
 mod any;
 mod any_attribute;
 mod attribute;
+mod attribute_group;
 mod choice;
 mod complex_content;
 mod complex_type;
@@ -43,9 +44,15 @@ pub fn parse(text: &str) -> Result<RsFile, ()> {
             map.extend(st.get_types_map());
         }
     }
+    for ag in &schema_rs.attribute_groups {
+        if let RsEntity::Struct(st) = ag {
+            map.extend(st.get_types_map());
+        }
+    }
     for ty in &schema_rs.types {
         if let RsEntity::Struct(st) = ty {
             st.extend_base(&map);
+            st.extend_attribute_group(&map);
         }
     }
 

--- a/xsd-parser/src/parser/node_parser.rs
+++ b/xsd-parser/src/parser/node_parser.rs
@@ -3,6 +3,7 @@ use roxmltree::Node;
 use crate::parser::any::parse_any;
 use crate::parser::any_attribute::parse_any_attribute;
 use crate::parser::attribute::parse_attribute;
+use crate::parser::attribute_group::parse_attribute_group;
 use crate::parser::choice::parse_choice;
 use crate::parser::complex_content::parse_complex_content;
 use crate::parser::complex_type::parse_complex_type;
@@ -25,6 +26,7 @@ pub fn parse_node(node: &Node, parent: &Node) -> RsEntity {
         Any => parse_any(node),
         AnyAttribute => parse_any_attribute(node),
         Attribute => parse_attribute(node, parent),
+        AttributeGroup => parse_attribute_group(node, parent),
         Choice => parse_choice(node),
         ComplexContent => parse_complex_content(node),
         ComplexType => parse_complex_type(node, parent),

--- a/xsd-parser/src/parser/restriction.rs
+++ b/xsd-parser/src/parser/restriction.rs
@@ -6,7 +6,9 @@ use crate::parser::types::{
     Enum, EnumCase, EnumSource, Facet, RsEntity, Struct, StructField, StructFieldSource,
     TupleStruct,
 };
-use crate::parser::utils::{attributes_to_fields, attribute_groups_to_aliases, get_base, get_documentation, get_parent_name};
+use crate::parser::utils::{
+    attribute_groups_to_aliases, attributes_to_fields, get_base, get_documentation, get_parent_name,
+};
 use crate::parser::xsd_elements::{ElementType, FacetType, RestrictionType, XsdNode};
 use roxmltree::Node;
 

--- a/xsd-parser/src/parser/restriction.rs
+++ b/xsd-parser/src/parser/restriction.rs
@@ -6,7 +6,7 @@ use crate::parser::types::{
     Enum, EnumCase, EnumSource, Facet, RsEntity, Struct, StructField, StructFieldSource,
     TupleStruct,
 };
-use crate::parser::utils::{attributes_to_fields, get_base, get_documentation, get_parent_name};
+use crate::parser::utils::{attributes_to_fields, attribute_groups_to_aliases, get_base, get_documentation, get_parent_name};
 use crate::parser::xsd_elements::{ElementType, FacetType, RestrictionType, XsdNode};
 use roxmltree::Node;
 
@@ -93,6 +93,7 @@ fn complex_content_restriction(node: &Node) -> RsEntity {
     RsEntity::Struct(Struct {
         comment: get_documentation(node),
         fields: RefCell::new(fields),
+        attribute_groups: RefCell::new(attribute_groups_to_aliases(node)),
         ..Default::default()
     })
 }

--- a/xsd-parser/src/parser/schema.rs
+++ b/xsd-parser/src/parser/schema.rs
@@ -25,6 +25,14 @@ pub fn parse_schema<'input>(schema: &Node<'_, 'input>) -> RsFile<'input> {
             })
             .map(|node| parse_node(&node, schema))
             .collect(),
+        attribute_groups: schema
+            .children()
+            .filter(|n| {
+                n.is_element()
+                    && n.xsd_type() == ElementType::AttributeGroup
+            })
+            .map(|node| parse_node(&node, schema))
+            .collect(),
     }
 }
 

--- a/xsd-parser/src/parser/schema.rs
+++ b/xsd-parser/src/parser/schema.rs
@@ -27,10 +27,7 @@ pub fn parse_schema<'input>(schema: &Node<'_, 'input>) -> RsFile<'input> {
             .collect(),
         attribute_groups: schema
             .children()
-            .filter(|n| {
-                n.is_element()
-                    && n.xsd_type() == ElementType::AttributeGroup
-            })
+            .filter(|n| n.is_element() && n.xsd_type() == ElementType::AttributeGroup)
             .map(|node| parse_node(&node, schema))
             .collect(),
     }

--- a/xsd-parser/src/parser/sequence.rs
+++ b/xsd-parser/src/parser/sequence.rs
@@ -14,6 +14,7 @@ pub fn parse_sequence(sequence: &Node, parent: &Node) -> RsEntity {
         comment: get_documentation(parent),
         subtypes: vec![],
         fields: RefCell::new(elements_to_fields(sequence, name)),
+        ..Default::default()
     })
 }
 

--- a/xsd-parser/src/parser/types.rs
+++ b/xsd-parser/src/parser/types.rs
@@ -10,6 +10,7 @@ pub struct RsFile<'input> {
     pub name: String,
     pub namespace: Option<String>,
     pub types: Vec<RsEntity>,
+    pub attribute_groups: Vec<RsEntity>,
     pub target_ns: Option<Namespace<'input>>,
     pub xsd_ns: Option<Namespace<'input>>,
 }
@@ -19,6 +20,7 @@ pub struct Struct {
     pub name: String,
     pub comment: Option<String>,
     pub fields: RefCell<Vec<StructField>>,
+    pub attribute_groups: RefCell<Vec<Alias>>,
     pub subtypes: Vec<RsEntity>,
 }
 
@@ -73,6 +75,23 @@ impl Struct {
                 s.extend_base(types);
             }
         }
+    }
+
+    pub fn extend_attribute_group(&self, types: &HashMap<&String, &Self>) {
+        let mut fields = self
+            .attribute_groups
+            .borrow()
+            .iter()
+            .flat_map(|f| {
+                let key = f.original.split(':').last().unwrap().to_string();
+                types
+                    .get(&key)
+                    .map(|s| s.fields.borrow().clone())
+                    .unwrap_or_else(Vec::new)
+            })
+            .collect::<Vec<StructField>>();
+
+        self.fields.borrow_mut().append(&mut fields);
     }
 }
 

--- a/xsd-parser/src/parser/utils.rs
+++ b/xsd-parser/src/parser/utils.rs
@@ -6,7 +6,7 @@ use roxmltree::{Namespace, Node};
 
 use crate::parser::constants::attribute;
 use crate::parser::node_parser::parse_node;
-use crate::parser::types::{Enum, RsEntity, StructField, StructFieldSource, Alias};
+use crate::parser::types::{Alias, Enum, RsEntity, StructField, StructFieldSource};
 use crate::parser::xsd_elements::{ElementType, XsdNode};
 
 pub fn target_namespace<'a, 'input>(node: &Node<'a, 'input>) -> Option<&'a Namespace<'input>> {
@@ -62,9 +62,7 @@ pub fn attributes_to_fields(node: &Node) -> Vec<StructField> {
 
 pub fn attribute_groups_to_aliases(node: &Node) -> Vec<Alias> {
     node.children()
-        .filter(|n| {
-            n.xsd_type() == ElementType::AttributeGroup
-        })
+        .filter(|n| n.xsd_type() == ElementType::AttributeGroup)
         .map(|n| match parse_node(&n, node) {
             RsEntity::Alias(a) => a,
             _ => unreachable!("Invalid attribute group parsing: {:?}", n),

--- a/xsd-parser/src/parser/utils.rs
+++ b/xsd-parser/src/parser/utils.rs
@@ -6,7 +6,7 @@ use roxmltree::{Namespace, Node};
 
 use crate::parser::constants::attribute;
 use crate::parser::node_parser::parse_node;
-use crate::parser::types::{Enum, RsEntity, StructField, StructFieldSource};
+use crate::parser::types::{Enum, RsEntity, StructField, StructFieldSource, Alias};
 use crate::parser::xsd_elements::{ElementType, XsdNode};
 
 pub fn target_namespace<'a, 'input>(node: &Node<'a, 'input>) -> Option<&'a Namespace<'input>> {
@@ -56,6 +56,18 @@ pub fn attributes_to_fields(node: &Node) -> Vec<StructField> {
         .map(|n| match parse_node(&n, node) {
             RsEntity::StructField(sf) => sf,
             _ => unreachable!("Invalid attribute parsing: {:?}", n),
+        })
+        .collect()
+}
+
+pub fn attribute_groups_to_aliases(node: &Node) -> Vec<Alias> {
+    node.children()
+        .filter(|n| {
+            n.xsd_type() == ElementType::AttributeGroup
+        })
+        .map(|n| match parse_node(&n, node) {
+            RsEntity::Alias(a) => a,
+            _ => unreachable!("Invalid attribute group parsing: {:?}", n),
         })
         .collect()
 }


### PR DESCRIPTION
This pull-requests adds support for `AttributeGroup` to xsd-parser. 

The implementation has three main impacts:
* `RsFile` has a new collection to store `AttributeGroup` definitions; 
* Global `AttributeGroup`s are parsed as `Struct`s and their attributes as `StructField`s;
* `Struct`s have a new collection of `Alias`es for the attribute groups they implement;
* The parsing of non-global `AttributeGroup` is implemented in all elements allowed to contain an `AttributeGroup`: `extension`, `restriction` and `complexType`.

With this implementation, the `struct`s generated for types referencing an `AttributeGroup` have all the fields provided by the `AttributeGroup`. No `struct` is generated for the `AttributeGroup` itself, which seems correct since `AttributeGroup`s cannot appear as such in a XML file.