### PR TITLE
upgraded to roxmltree 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,27 +14,36 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
+name = "android_system_properties"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "7724808837b77f4b4de9d283820f9d98bcf496d5692934b857a2399d31ff22e6"
 
 [[package]]
 name = "atty"
@@ -49,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bigdecimal"
@@ -66,9 +75,21 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bumpalo"
+version = "3.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "cc"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -78,22 +99,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "time",
+ "wasm-bindgen",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -102,6 +125,66 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cxx"
+version = "1.0.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27874566aca772cb515af4c6e997b5fe2119820bca447689145e39bb734d19a0"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb951f2523a49533003656a72121306b225ec16a49a09dc6b0ba0d6f3ec3c0"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be778b6327031c1c7b61dd2e48124eee5361e6aa76b8de93692f011b08870ab4"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8a2b87662fe5a0a0b38507756ab66aff32638876a0866e5a5fc82ceb07ee49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -115,12 +198,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -129,6 +209,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -149,30 +262,39 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.99"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -181,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -191,36 +313,42 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.28"
+name = "once_cell"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d89e5dba24725ae5678020bf8f1357a9aa7ff10736b551adbcd3f8d17d766f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "556d0f47a940e895261e77dc200d5eadfc6ef644c179c6f5edfc105e3a2292c8"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -229,18 +357,24 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "roxmltree"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+checksum = "fb6d47b59770b0ae88c7f270c68502832ec14d8c7ab5f7a584f204bb76dbfd8e"
 dependencies = [
  "xmlparser",
 ]
+
+[[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "strsim"
@@ -250,13 +384,13 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "09ee3a69cd2c7e06684677e5629b3878b253af05e4714964204279c6bc02cf0b"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -267,6 +401,15 @@ checksum = "f2077e54d38055cf1ca0fd7933a2e00cd3ec8f6fed352b2a377f06dcdaaf3281"
 dependencies = [
  "kernel32-sys",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -290,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi",
@@ -300,22 +443,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
+name = "unicode-ident"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "vec_map"
@@ -328,6 +465,60 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "winapi"
@@ -356,6 +547,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -393,9 +593,9 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xmlparser"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 
 [[package]]
 name = "xsd-macro-utils"
@@ -446,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "yaserde"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2776ec5bb20e76d89268e87e1ea66c078b94f55e9771e4d648adda3019f87fc"
+checksum = "4bf52af554a50b866aaad63d7eabd6fca298db3dfe49afd50b7ba5a33dfa0582"
 dependencies = [
  "log",
  "xml-rs",
@@ -456,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "yaserde_derive"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0b0a4701f203ebaecce4971a6bb8575aa07b617bdc39ddfc6ffeff3a38530d"
+checksum = "7ab8bd5c76eebb8380b26833d30abddbdd885b00dd06178412e0d51d5bfc221f"
 dependencies = [
  "heck",
  "log",

--- a/wsdl-parser-cli/Cargo.toml
+++ b/wsdl-parser-cli/Cargo.toml
@@ -17,6 +17,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.42"
 clap = "2.33.3"
-roxmltree = { version = "0.14.0", features = ["std"] }
+roxmltree = { version = "0.16.0", features = ["std"] }
 wsdl-parser = { path = "../wsdl-parser" }
 xsd-parser = { path = "../xsd-parser" }

--- a/wsdl-parser/Cargo.toml
+++ b/wsdl-parser/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 Inflector = "0.11.4"
-roxmltree = "0.14.0"
+roxmltree = "0.16.0"
 
 [dev-dependencies]
 syn = { version = "1.0.58", features = ["full"] }

--- a/xsd-parser/Cargo.toml
+++ b/xsd-parser/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 Inflector = "0.11.4"
-roxmltree = "0.14.0"
+roxmltree = "0.16.0"
 
 [dev-dependencies]
 num-bigint = "0.4.2"
@@ -21,5 +21,5 @@ text-diff = "0.4.0"
 xml-rs = "0.8.3"
 xsd-macro-utils = { path = "../xsd-macro-utils" }
 xsd-types = { path = "../xsd-types" }
-yaserde = "0.7.1"
-yaserde_derive = "0.7.1"
+yaserde = "0.8.0"
+yaserde_derive = "0.8.0"

--- a/xsd-types/Cargo.toml
+++ b/xsd-types/Cargo.toml
@@ -16,7 +16,7 @@ chrono = "0.4.19"
 num-bigint = "0.4.2"
 xml-rs = "0.8.3"
 xsd-macro-utils = { path = "../xsd-macro-utils" }
-yaserde = "0.7.1"
+yaserde = "0.8.0"
 
 [dev-dependencies]
-yaserde_derive = "0.7.1"
+yaserde_derive = "0.8.0"

--- a/xsd-types/src/types/date.rs
+++ b/xsd-types/src/types/date.rs
@@ -26,7 +26,7 @@ impl Date {
 impl Default for Date {
     fn default() -> Date {
         Self {
-            value: NaiveDate::from_ymd(1, 1, 1),
+            value: NaiveDate::from_ymd_opt(1, 1, 1).unwrap(),
             timezone: None,
         }
     }
@@ -43,7 +43,7 @@ impl FromStr for Date {
         if let Some(s) = s.strip_suffix('Z') {
             return Ok(Date {
                 value: parse_naive_date(s)?,
-                timezone: Some(FixedOffset::east(0)),
+                timezone: Some(FixedOffset::east_opt(0).unwrap()),
             });
         }
 
@@ -100,7 +100,7 @@ mod tests {
         assert_eq!(
             Date::from_str("2020-02-02"),
             Ok(Date {
-                value: NaiveDate::from_ymd(2020, 2, 2),
+                value: NaiveDate::from_ymd_opt(2020, 2, 2).unwrap(),
                 timezone: None
             })
         );
@@ -109,8 +109,8 @@ mod tests {
         assert_eq!(
             Date::from_str("2020-02-02Z"),
             Ok(Date {
-                value: NaiveDate::from_ymd(2020, 2, 2),
-                timezone: Some(FixedOffset::east(0))
+                value: NaiveDate::from_ymd_opt(2020, 2, 2).unwrap(),
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             })
         );
 
@@ -118,8 +118,8 @@ mod tests {
         assert_eq!(
             Date::from_str("2020-02-02+06:30"),
             Ok(Date {
-                value: NaiveDate::from_ymd(2020, 2, 2),
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                value: NaiveDate::from_ymd_opt(2020, 2, 2).unwrap(),
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -127,8 +127,8 @@ mod tests {
         assert_eq!(
             Date::from_str("2020-02-02-06:30"),
             Ok(Date {
-                value: NaiveDate::from_ymd(2020, 2, 2),
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                value: NaiveDate::from_ymd_opt(2020, 2, 2).unwrap(),
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
     }
@@ -138,7 +138,7 @@ mod tests {
         // No timezone.
         assert_eq!(
             Date {
-                value: NaiveDate::from_ymd(2020, 2, 2),
+                value: NaiveDate::from_ymd_opt(2020, 2, 2).unwrap(),
                 timezone: None
             }
             .to_string(),
@@ -148,8 +148,8 @@ mod tests {
         // Timezone +00:00.
         assert_eq!(
             Date {
-                value: NaiveDate::from_ymd(2020, 2, 2),
-                timezone: Some(FixedOffset::east(0))
+                value: NaiveDate::from_ymd_opt(2020, 2, 2).unwrap(),
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             }
             .to_string(),
             "2020-02-02+00:00"
@@ -158,8 +158,8 @@ mod tests {
         // Positive offset.
         assert_eq!(
             Date {
-                value: NaiveDate::from_ymd(2020, 2, 2),
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                value: NaiveDate::from_ymd_opt(2020, 2, 2).unwrap(),
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "2020-02-02+06:30"
@@ -168,8 +168,8 @@ mod tests {
         // Negative offset.
         assert_eq!(
             Date {
-                value: NaiveDate::from_ymd(2020, 2, 2),
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                value: NaiveDate::from_ymd_opt(2020, 2, 2).unwrap(),
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "2020-02-02-06:30"
@@ -197,8 +197,8 @@ mod tests {
             "#;
         let m = Message {
             created_at: Date {
-                value: NaiveDate::from_ymd(2020, 2, 2),
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60)),
+                value: NaiveDate::from_ymd_opt(2020, 2, 2).unwrap(),
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap()),
             },
             text: "Hello world".to_string(),
         };
@@ -216,10 +216,10 @@ mod tests {
             </t:Message>
             "#;
         let m: Message = yaserde::de::from_str(s).unwrap();
-        assert_eq!(m.created_at.value, NaiveDate::from_ymd(2020, 2, 2));
+        assert_eq!(m.created_at.value, NaiveDate::from_ymd_opt(2020, 2, 2).unwrap());
         assert_eq!(
             m.created_at.timezone,
-            Some(FixedOffset::west(6 * 3600 + 30 * 60)),
+            Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap()),
         );
         assert_eq!(m.text, "Hello world".to_string());
     }

--- a/xsd-types/src/types/datetime.rs
+++ b/xsd-types/src/types/datetime.rs
@@ -64,8 +64,8 @@ mod tests {
     #[test]
     fn datetime_parse_test() {
         // No timezone.
-        let offset = FixedOffset::east(0);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::east_opt(0).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert_eq!(
             DateTime::from_str("2020-03-07T04:40:00"),
@@ -78,8 +78,8 @@ mod tests {
         );
 
         // Positive offset.
-        let offset = FixedOffset::east(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert_eq!(
             DateTime::from_str("2020-03-07T04:40:00+06:30"),
@@ -87,8 +87,8 @@ mod tests {
         );
 
         // Negative offset.
-        let offset = FixedOffset::west(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert_eq!(
             DateTime::from_str("2020-03-07T04:40:00-06:30"),
@@ -99,8 +99,8 @@ mod tests {
     #[test]
     fn datetime_display_test() {
         // Timezone +00:00.
-        let offset = FixedOffset::east(0);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::east_opt(0).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert_eq!(
             DateTime { value: dt }.to_string(),
@@ -108,8 +108,8 @@ mod tests {
         );
 
         // Positive offset.
-        let offset = FixedOffset::east(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert_eq!(
             DateTime { value: dt }.to_string(),
@@ -117,8 +117,8 @@ mod tests {
         );
 
         // Negative offset.
-        let offset = FixedOffset::west(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert_eq!(
             DateTime { value: dt }.to_string(),
@@ -146,8 +146,8 @@ mod tests {
             </t:Message>
             "#;
 
-        let offset = FixedOffset::east(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         let m = Message {
             created_at: DateTime { value: dt },
@@ -168,8 +168,8 @@ mod tests {
             "#;
         let m: Message = yaserde::de::from_str(s).unwrap();
 
-        let offset = FixedOffset::west(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
 
         assert_eq!(m.created_at.value, dt);

--- a/xsd-types/src/types/datetimestamp.rs
+++ b/xsd-types/src/types/datetimestamp.rs
@@ -49,8 +49,11 @@ mod tests {
     #[test]
     fn datetime_parse_test() {
         // No timezone.
-        let offset = FixedOffset::east(0);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::east_opt(0).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7)
+            .unwrap()
+            .and_hms_opt(4, 40, 0).unwrap()
+            - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert!(DateTimeStamp::from_str("2020-03-07T04:40:00").is_err());
         // Timezone "Z".
@@ -60,8 +63,8 @@ mod tests {
         );
 
         // Positive offset.
-        let offset = FixedOffset::east(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert_eq!(
             DateTimeStamp::from_str("2020-03-07T04:40:00+06:30"),
@@ -69,8 +72,8 @@ mod tests {
         );
 
         // Negative offset.
-        let offset = FixedOffset::west(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert_eq!(
             DateTimeStamp::from_str("2020-03-07T04:40:00-06:30"),
@@ -81,8 +84,8 @@ mod tests {
     #[test]
     fn datetime_display_test() {
         // Timezone +00:00.
-        let offset = FixedOffset::east(0);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::east_opt(0).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert_eq!(
             DateTimeStamp::from_chrono_datetime(dt).to_string(),
@@ -90,8 +93,8 @@ mod tests {
         );
 
         // Positive offset.
-        let offset = FixedOffset::east(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert_eq!(
             DateTimeStamp::from_chrono_datetime(dt).to_string(),
@@ -99,8 +102,8 @@ mod tests {
         );
 
         // Negative offset.
-        let offset = FixedOffset::west(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         assert_eq!(
             DateTimeStamp::from_chrono_datetime(dt).to_string(),
@@ -128,8 +131,8 @@ mod tests {
             </t:Message>
             "#;
 
-        let offset = FixedOffset::east(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
         let m = Message {
             created_at: DateTimeStamp::from_chrono_datetime(dt),
@@ -150,8 +153,8 @@ mod tests {
             "#;
         let m: Message = yaserde::de::from_str(s).unwrap();
 
-        let offset = FixedOffset::west(6 * 3600 + 30 * 60);
-        let dt_utc = NaiveDate::from_ymd(2020, 3, 7).and_hms(4, 40, 0) - offset;
+        let offset = FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap();
+        let dt_utc = NaiveDate::from_ymd_opt(2020, 3, 7).unwrap().and_hms_opt(4, 40, 0).unwrap() - offset;
         let dt = CDateTime::<FixedOffset>::from_utc(dt_utc, offset);
 
         assert_eq!(m.created_at.value, DateTime::from_chrono_datetime(dt));

--- a/xsd-types/src/types/gday.rs
+++ b/xsd-types/src/types/gday.rs
@@ -48,7 +48,7 @@ impl FromStr for GDay {
         }
 
         if let Some(s) = s.strip_suffix('Z') {
-            return GDay::new(parse_value(s)?, Some(FixedOffset::east(0)));
+            return GDay::new(parse_value(s)?, Some(FixedOffset::east_opt(0).unwrap()));
         }
 
         if s.contains('+') {
@@ -104,7 +104,7 @@ mod tests {
             GDay::from_str("---25Z"),
             Ok(GDay {
                 value: 25,
-                timezone: Some(FixedOffset::east(0))
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             })
         );
 
@@ -113,7 +113,7 @@ mod tests {
             GDay::from_str("---25+06:30"),
             Ok(GDay {
                 value: 25,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -122,7 +122,7 @@ mod tests {
             GDay::from_str("---25-06:30"),
             Ok(GDay {
                 value: 25,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(
             GDay {
                 value: 3,
-                timezone: Some(FixedOffset::east(0))
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             }
             .to_string(),
             "---03+00:00"
@@ -162,7 +162,7 @@ mod tests {
         assert_eq!(
             GDay {
                 value: 3,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "---03+06:30"
@@ -172,7 +172,7 @@ mod tests {
         assert_eq!(
             GDay {
                 value: 3,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "---03-06:30"
@@ -201,7 +201,7 @@ mod tests {
         let m = Message {
             created_at: GDay {
                 value: 7,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60)),
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap()),
             },
             text: "Hello world".to_string(),
         };
@@ -222,7 +222,7 @@ mod tests {
         assert_eq!(m.created_at.value, 29);
         assert_eq!(
             m.created_at.timezone,
-            Some(FixedOffset::west(6 * 3600 + 30 * 60)),
+            Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap()),
         );
         assert_eq!(m.text, "Hello world".to_string());
     }

--- a/xsd-types/src/types/gmonth.rs
+++ b/xsd-types/src/types/gmonth.rs
@@ -48,7 +48,7 @@ impl FromStr for GMonth {
         }
 
         if let Some(s) = s.strip_suffix('Z') {
-            return GMonth::new(parse_value(s)?, Some(FixedOffset::east(0)));
+            return GMonth::new(parse_value(s)?, Some(FixedOffset::east_opt(0).unwrap()));
         }
 
         if s.contains('+') {
@@ -104,7 +104,7 @@ mod tests {
             GMonth::from_str("--12Z"),
             Ok(GMonth {
                 value: 12,
-                timezone: Some(FixedOffset::east(0))
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             })
         );
 
@@ -113,7 +113,7 @@ mod tests {
             GMonth::from_str("--12+06:30"),
             Ok(GMonth {
                 value: 12,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -122,7 +122,7 @@ mod tests {
             GMonth::from_str("--12-06:30"),
             Ok(GMonth {
                 value: 12,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(
             GMonth {
                 value: 3,
-                timezone: Some(FixedOffset::east(0))
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             }
             .to_string(),
             "--03+00:00"
@@ -162,7 +162,7 @@ mod tests {
         assert_eq!(
             GMonth {
                 value: 3,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "--03+06:30"
@@ -172,7 +172,7 @@ mod tests {
         assert_eq!(
             GMonth {
                 value: 3,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "--03-06:30"
@@ -201,7 +201,7 @@ mod tests {
         let m = Message {
             created_at: GMonth {
                 value: 7,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60)),
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap()),
             },
             text: "Hello world".to_string(),
         };
@@ -222,7 +222,7 @@ mod tests {
         assert_eq!(m.created_at.value, 9);
         assert_eq!(
             m.created_at.timezone,
-            Some(FixedOffset::west(6 * 3600 + 30 * 60)),
+            Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap()),
         );
         assert_eq!(m.text, "Hello world".to_string());
     }

--- a/xsd-types/src/types/gmonthday.rs
+++ b/xsd-types/src/types/gmonthday.rs
@@ -87,7 +87,7 @@ impl FromStr for GMonthDay {
 
         if let Some(s) = s.strip_suffix('Z') {
             let (month, day) = parse_value(s)?;
-            return GMonthDay::new(month, day, Some(FixedOffset::east(0)));
+            return GMonthDay::new(month, day, Some(FixedOffset::east_opt(0).unwrap()));
         }
 
         if s.contains('+') {
@@ -148,7 +148,7 @@ mod tests {
             Ok(GMonthDay {
                 month: 12,
                 day: 20,
-                timezone: Some(FixedOffset::east(0))
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             })
         );
 
@@ -158,7 +158,7 @@ mod tests {
             Ok(GMonthDay {
                 month: 12,
                 day: 20,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -168,7 +168,7 @@ mod tests {
             Ok(GMonthDay {
                 month: 12,
                 day: 20,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -205,7 +205,7 @@ mod tests {
             GMonthDay {
                 month: 3,
                 day: 2,
-                timezone: Some(FixedOffset::east(0))
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             }
             .to_string(),
             "--03-02+00:00"
@@ -216,7 +216,7 @@ mod tests {
             GMonthDay {
                 month: 3,
                 day: 2,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "--03-02+06:30"
@@ -227,7 +227,7 @@ mod tests {
             GMonthDay {
                 month: 3,
                 day: 2,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "--03-02-06:30"
@@ -257,7 +257,7 @@ mod tests {
             created_at: GMonthDay {
                 month: 7,
                 day: 9,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60)),
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap()),
             },
             text: "Hello world".to_string(),
         };
@@ -279,7 +279,7 @@ mod tests {
         assert_eq!(m.created_at.day, 9);
         assert_eq!(
             m.created_at.timezone,
-            Some(FixedOffset::west(6 * 3600 + 30 * 60)),
+            Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap()),
         );
         assert_eq!(m.text, "Hello world".to_string());
     }

--- a/xsd-types/src/types/gyear.rs
+++ b/xsd-types/src/types/gyear.rs
@@ -60,7 +60,7 @@ fn parse_str_positive(s: &str) -> Result<GYear, String> {
     }
 
     if let Some(s) = s.strip_suffix('Z') {
-        return GYear::new(parse_value(s)?, Some(FixedOffset::east(0)));
+        return GYear::new(parse_value(s)?, Some(FixedOffset::east_opt(0).unwrap()));
     }
 
     if s.contains('+') {
@@ -126,7 +126,7 @@ mod tests {
             GYear::from_str("2020Z"),
             Ok(GYear {
                 value: 2020,
-                timezone: Some(FixedOffset::east(0))
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             })
         );
 
@@ -135,7 +135,7 @@ mod tests {
             GYear::from_str("2020+06:30"),
             Ok(GYear {
                 value: 2020,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -144,7 +144,7 @@ mod tests {
             GYear::from_str("2020-06:30"),
             Ok(GYear {
                 value: 2020,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -153,7 +153,7 @@ mod tests {
             GYear::from_str("-0020-06:30"),
             Ok(GYear {
                 value: -20,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -162,7 +162,7 @@ mod tests {
             GYear::from_str("-20000-06:30"),
             Ok(GYear {
                 value: -20000,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -189,7 +189,7 @@ mod tests {
         assert_eq!(
             GYear {
                 value: 987,
-                timezone: Some(FixedOffset::east(0))
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             }
             .to_string(),
             "0987+00:00"
@@ -199,7 +199,7 @@ mod tests {
         assert_eq!(
             GYear {
                 value: 987,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "0987+06:30"
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(
             GYear {
                 value: 987,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "0987-06:30"
@@ -219,7 +219,7 @@ mod tests {
         assert_eq!(
             GYear {
                 value: -987,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "-0987-06:30"
@@ -229,7 +229,7 @@ mod tests {
         assert_eq!(
             GYear {
                 value: -98765,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "-98765-06:30"
@@ -258,7 +258,7 @@ mod tests {
         let m = Message {
             created_at: GYear {
                 value: 2007,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60)),
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap()),
             },
             text: "Hello world".to_string(),
         };
@@ -279,7 +279,7 @@ mod tests {
         assert_eq!(m.created_at.value, 2007);
         assert_eq!(
             m.created_at.timezone,
-            Some(FixedOffset::west(6 * 3600 + 30 * 60)),
+            Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap()),
         );
         assert_eq!(m.text, "Hello world".to_string());
     }

--- a/xsd-types/src/types/gyearmonth.rs
+++ b/xsd-types/src/types/gyearmonth.rs
@@ -101,7 +101,7 @@ fn parse_str_positive(s: &str) -> Result<GYearMonth, String> {
 
     if let Some(s) = s.strip_suffix('Z') {
         let (year, month) = parse_value(s)?;
-        return GYearMonth::new(year, month, Some(FixedOffset::east(0)));
+        return GYearMonth::new(year, month, Some(FixedOffset::east_opt(0).unwrap()));
     }
 
     if s.contains('+') {
@@ -168,7 +168,7 @@ mod tests {
             Ok(GYearMonth {
                 year: 2020,
                 month: 3,
-                timezone: Some(FixedOffset::east(0))
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             })
         );
 
@@ -178,7 +178,7 @@ mod tests {
             Ok(GYearMonth {
                 year: 2020,
                 month: 3,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -188,7 +188,7 @@ mod tests {
             Ok(GYearMonth {
                 year: 2020,
                 month: 3,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -198,7 +198,7 @@ mod tests {
             Ok(GYearMonth {
                 year: -20,
                 month: 3,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -208,7 +208,7 @@ mod tests {
             Ok(GYearMonth {
                 year: -20000,
                 month: 3,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -242,7 +242,7 @@ mod tests {
             GYearMonth {
                 year: 987,
                 month: 6,
-                timezone: Some(FixedOffset::east(0))
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             }
             .to_string(),
             "0987-06+00:00"
@@ -253,7 +253,7 @@ mod tests {
             GYearMonth {
                 year: 987,
                 month: 6,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "0987-06+06:30"
@@ -264,7 +264,7 @@ mod tests {
             GYearMonth {
                 year: 987,
                 month: 6,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "0987-06-06:30"
@@ -275,7 +275,7 @@ mod tests {
             GYearMonth {
                 year: -987,
                 month: 6,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "-0987-06-06:30"
@@ -286,7 +286,7 @@ mod tests {
             GYearMonth {
                 year: -98765,
                 month: 6,
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "-98765-06-06:30"
@@ -316,7 +316,7 @@ mod tests {
             created_at: GYearMonth {
                 year: 2007,
                 month: 2,
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60)),
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap()),
             },
             text: "Hello world".to_string(),
         };
@@ -338,7 +338,7 @@ mod tests {
         assert_eq!(m.created_at.month, 2);
         assert_eq!(
             m.created_at.timezone,
-            Some(FixedOffset::west(6 * 3600 + 30 * 60)),
+            Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap()),
         );
         assert_eq!(m.text, "Hello world".to_string());
     }

--- a/xsd-types/src/types/time.rs
+++ b/xsd-types/src/types/time.rs
@@ -26,7 +26,7 @@ impl Time {
 impl Default for Time {
     fn default() -> Time {
         Self {
-            value: NaiveTime::from_hms(0, 0, 0),
+            value: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
             timezone: None,
         }
     }
@@ -43,7 +43,7 @@ impl FromStr for Time {
         if let Some(s) = s.strip_suffix('Z') {
             return Ok(Time {
                 value: parse_naive_time(s)?,
-                timezone: Some(FixedOffset::east(0)),
+                timezone: Some(FixedOffset::east_opt(0).unwrap()),
             });
         }
 
@@ -104,7 +104,7 @@ mod tests {
         assert_eq!(
             Time::from_str("04:40:00"),
             Ok(Time {
-                value: NaiveTime::from_hms(4, 40, 0),
+                value: NaiveTime::from_hms_opt(4, 40, 0).unwrap(),
                 timezone: None
             })
         );
@@ -113,8 +113,8 @@ mod tests {
         assert_eq!(
             Time::from_str("04:40:00Z"),
             Ok(Time {
-                value: NaiveTime::from_hms(4, 40, 0),
-                timezone: Some(FixedOffset::east(0))
+                value: NaiveTime::from_hms_opt(4, 40, 0).unwrap(),
+                timezone: Some(FixedOffset::east_opt(0).unwrap())
             })
         );
 
@@ -122,8 +122,8 @@ mod tests {
         assert_eq!(
             Time::from_str("04:40:00+06:30"),
             Ok(Time {
-                value: NaiveTime::from_hms(4, 40, 0),
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                value: NaiveTime::from_hms_opt(4, 40, 0).unwrap(),
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
 
@@ -131,8 +131,8 @@ mod tests {
         assert_eq!(
             Time::from_str("04:40:00-06:30"),
             Ok(Time {
-                value: NaiveTime::from_hms(4, 40, 0),
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                value: NaiveTime::from_hms_opt(4, 40, 0).unwrap(),
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             })
         );
     }
@@ -142,7 +142,7 @@ mod tests {
         // No timezone.
         assert_eq!(
             Time {
-                value: NaiveTime::from_hms(4, 40, 0),
+                value: NaiveTime::from_hms_opt(4, 40, 0).unwrap(),
                 timezone: None
             }
             .to_string(),
@@ -152,8 +152,8 @@ mod tests {
         // Timezone +00:00.
         assert_eq!(
             Time {
-                value: NaiveTime::from_hms(4, 40, 0),
-                timezone: Some(FixedOffset::east(0))
+                value: NaiveTime::from_hms_opt(4, 40, 0).unwrap(),
+                timezone: Some(FixedOffset::east_opt(0)).unwrap()
             }
             .to_string(),
             "04:40:00+00:00"
@@ -162,8 +162,8 @@ mod tests {
         // Positive offset.
         assert_eq!(
             Time {
-                value: NaiveTime::from_hms(4, 40, 0),
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60))
+                value: NaiveTime::from_hms_opt(4, 40, 0).unwrap(),
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "04:40:00+06:30"
@@ -172,8 +172,8 @@ mod tests {
         // Negative offset.
         assert_eq!(
             Time {
-                value: NaiveTime::from_hms(4, 40, 0),
-                timezone: Some(FixedOffset::west(6 * 3600 + 30 * 60))
+                value: NaiveTime::from_hms_opt(4, 40, 0).unwrap(),
+                timezone: Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
             }
             .to_string(),
             "04:40:00-06:30"
@@ -201,8 +201,8 @@ mod tests {
             "#;
         let m = Message {
             created_at: Time {
-                value: NaiveTime::from_hms(4, 40, 0),
-                timezone: Some(FixedOffset::east(6 * 3600 + 30 * 60)),
+                value: NaiveTime::from_hms_opt(4, 40, 0).unwrap(),
+                timezone: Some(FixedOffset::east_opt(6 * 3600 + 30 * 60)).unwrap(),
             },
             text: "Hello world".to_string(),
         };
@@ -220,10 +220,10 @@ mod tests {
             </t:Message>
             "#;
         let m: Message = yaserde::de::from_str(s).unwrap();
-        assert_eq!(m.created_at.value, NaiveTime::from_hms(4, 40, 0));
+        assert_eq!(m.created_at.value, NaiveTime::from_hms_opt(4, 40, 0).unwrap());
         assert_eq!(
             m.created_at.timezone,
-            Some(FixedOffset::west(6 * 3600 + 30 * 60))
+            Some(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
         );
         assert_eq!(m.text, "Hello world".to_string());
     }

--- a/xsd-types/src/types/utils.rs
+++ b/xsd-types/src/types/utils.rs
@@ -3,7 +3,7 @@ use chrono::FixedOffset;
 // Parses ISO 8601 timezone.
 pub fn parse_timezone(s: &str) -> Result<FixedOffset, String> {
     if s == "Z" {
-        return Ok(FixedOffset::east(0));
+        return Ok(FixedOffset::east_opt(0).unwrap());
     }
 
     let tokens: Vec<&str> = s[1..].split(':').collect();
@@ -23,8 +23,8 @@ pub fn parse_timezone(s: &str) -> Result<FixedOffset, String> {
 
     let offset_secs = 60 * (60 * hours + minutes);
     match s.chars().next().unwrap() {
-        '+' => Ok(FixedOffset::east(offset_secs)),
-        '-' => Ok(FixedOffset::west(offset_secs)),
+        '+' => Ok(FixedOffset::east_opt(offset_secs).unwrap()),
+        '-' => Ok(FixedOffset::west_opt(offset_secs).unwrap()),
         _ => Err("bad timezone format: timezone should start with '+' or '-'".to_string()),
     }
 }
@@ -36,25 +36,25 @@ mod tests {
     #[test]
     fn timezone_parse_test() {
         // Timezone "Z".
-        assert_eq!(parse_timezone("Z"), Ok(FixedOffset::east(0)));
+        assert_eq!(parse_timezone("Z"), Ok(FixedOffset::east_opt(0).unwrap()));
 
         // Positive offset.
         assert_eq!(
             parse_timezone("+06:30"),
-            Ok(FixedOffset::east(6 * 3600 + 30 * 60))
+            Ok(FixedOffset::east_opt(6 * 3600 + 30 * 60).unwrap())
         );
 
         // Negative offset.
         assert_eq!(
             parse_timezone("-06:30"),
-            Ok(FixedOffset::west(6 * 3600 + 30 * 60))
+            Ok(FixedOffset::west_opt(6 * 3600 + 30 * 60).unwrap())
         );
 
         // Positive offset max.
-        assert_eq!(parse_timezone("+14:00"), Ok(FixedOffset::east(14 * 3600)));
+        assert_eq!(parse_timezone("+14:00"), Ok(FixedOffset::east_opt(14 * 3600).unwrap()));
 
         // Negative offset max.
-        assert_eq!(parse_timezone("-14:00"), Ok(FixedOffset::west(14 * 3600)));
+        assert_eq!(parse_timezone("-14:00"), Ok(FixedOffset::west_opt(14 * 3600).unwrap()));
 
         // Invalid values.
         assert!(parse_timezone("06:30").is_err());


### PR DESCRIPTION
Upgrades the sources to use roxmltree  v0.16. For this replaced the deprecated functions with the new ones returning optionals and added calls to .unwrap().   Unwrap should be ok since the functions are all using arguments which are OK,

cargo test still passes