### PR TITLE
Stop Pascalizing Enum Cases

### DIFF
--- a/xsd-parser/src/generator/enum.rs
+++ b/xsd-parser/src/generator/enum.rs
@@ -61,8 +61,10 @@ pub trait EnumGenerator {
     }
 
     fn macros(&self, entity: &Enum, gen: &Generator) -> Cow<'static, str> {
+        let allows = "#[allow(non_camel_case_types)]\n";
+
         if entity.source == EnumSource::Union {
-            return "#[derive(PartialEq, Debug, UtilsUnionSerDe)]\n".into();
+            return format!("{allows}#[derive(PartialEq, Debug, UtilsUnionSerDe)]").into();
         }
 
         let derives = "#[derive(PartialEq, Debug, YaSerialize, YaDeserialize)]\n";
@@ -70,13 +72,13 @@ pub trait EnumGenerator {
         match tns.as_ref() {
             Some(tn) => match tn.name() {
                 Some(name) => format!(
-                    "{derives}#[yaserde(prefix = \"{prefix}\", namespace = \"{prefix}: {uri}\")]\n",
+                    "{allows}{derives}#[yaserde(prefix = \"{prefix}\", namespace = \"{prefix}: {uri}\")]\n",
                     derives = derives,
                     prefix = name,
                     uri = tn.uri()
                 ),
                 None => format!(
-                    "{derives}#[yaserde(namespace = \"{uri}\")]\n",
+                    "{allows}{derives}#[yaserde(namespace = \"{uri}\")]\n",
                     derives = derives,
                     uri = tn.uri()
                 ),

--- a/xsd-parser/src/generator/enum.rs
+++ b/xsd-parser/src/generator/enum.rs
@@ -19,7 +19,7 @@ pub trait EnumGenerator {
         );
 
         format!(
-            "{comment}{macros}\n\
+            "{comment}{macros}\
             pub enum {name} {{\n\
                 {cases}\n\
                 {indent}__Unknown__({typename}),\n\
@@ -62,10 +62,10 @@ pub trait EnumGenerator {
 
     fn macros(&self, entity: &Enum, gen: &Generator) -> Cow<'static, str> {
         if entity.source == EnumSource::Union {
-            return "#[derive(PartialEq, Debug, UtilsUnionSerDe)]".into();
+            return "#[derive(PartialEq, Debug, UtilsUnionSerDe)]\n".into();
         }
 
-        let derives = "#[derive(PartialEq, Debug, YaSerialize, YaDeserialize)]";
+        let derives = "#[derive(PartialEq, Debug, YaSerialize, YaDeserialize)]\n";
         let tns = gen.target_ns.borrow();
         match tns.as_ref() {
             Some(tn) => match tn.name() {

--- a/xsd-parser/src/generator/enum_case.rs
+++ b/xsd-parser/src/generator/enum_case.rs
@@ -1,7 +1,9 @@
 use crate::{
-    generator::{default::default_format_type, utils::split_name, Generator},
+    generator::{utils::split_name, Generator},
     parser::types::{EnumCase, EnumSource},
 };
+
+use super::utils::{filter_type_name, sanitize};
 
 pub trait EnumCaseGenerator {
     fn generate(&self, entity: &EnumCase, gen: &Generator) -> String {
@@ -20,12 +22,10 @@ pub trait EnumCaseGenerator {
         )
     }
 
-    fn get_name(&self, entity: &EnumCase, gen: &Generator) -> String {
-        default_format_type(entity.name.as_str(), &gen.target_ns.borrow())
-            .split("::")
-            .last()
-            .unwrap()
-            .to_string()
+    fn get_name(&self, entity: &EnumCase, _: &Generator) -> String {
+        sanitize(filter_type_name(
+            &entity.name.split(':').last().unwrap_or(&entity.name.to_owned()),
+        ))
     }
 
     fn get_type_name(&self, entity: &EnumCase, gen: &Generator) -> String {

--- a/xsd-parser/tests/enumeration/expected.rs
+++ b/xsd-parser/tests/enumeration/expected.rs
@@ -1,12 +1,9 @@
 #[derive(PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
 pub enum FooType {
-    #[yaserde(rename = "OFF")]
-    Off,
-    #[yaserde(rename = "ON")]
-    On,
-    #[yaserde(rename = "AUTO")]
-    Auto,
+    OFF,
+    ON,
+    AUTO,
     __Unknown__(String),
 }
 
@@ -17,9 +14,23 @@ impl Default for FooType {
 }
 impl Validate for FooType {}
 
+#[derive(PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+pub enum FooType1 {
+    OFF,
+    ON,
+    On,
+    __Unknown__(String),
+}
+
+impl Default for FooType1 {
+    fn default() -> FooType1 {
+        Self::__Unknown__("No valid variants".into())
+    }
+}
+impl Validate for FooType1 {}
 
 #[derive(Default, PartialEq, Debug, UtilsTupleIo, UtilsDefaultSerde)]
 pub struct FooType2(pub String);
 
 impl Validate for FooType2 {}
-

--- a/xsd-parser/tests/enumeration/expected.rs
+++ b/xsd-parser/tests/enumeration/expected.rs
@@ -1,3 +1,4 @@
+#[allow(non_camel_case_types)]
 #[derive(PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
 pub enum FooType {
@@ -14,6 +15,7 @@ impl Default for FooType {
 }
 impl Validate for FooType {}
 
+#[allow(non_camel_case_types)]
 #[derive(PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
 pub enum FooType1 {

--- a/xsd-parser/tests/enumeration/input.xsd
+++ b/xsd-parser/tests/enumeration/input.xsd
@@ -12,6 +12,14 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="FooType1">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="OFF"/>
+            <xs:enumeration value="ON"/>
+            <xs:enumeration value="On"/>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="FooType2">
         <xs:restriction base="xs:string">
             <xs:enumeration value="xs:OFF"/>

--- a/xsd-parser/tests/enumeration/mod.rs
+++ b/xsd-parser/tests/enumeration/mod.rs
@@ -16,7 +16,7 @@ fn deserialization_works() {
 
     let de: expected::FooType = yaserde::de::from_str(ser).unwrap();
 
-    assert_eq!(de, expected::FooType::Auto);
+    assert_eq!(de, expected::FooType::AUTO);
 }
 
 #[test]

--- a/xsd-parser/tests/union/expected.rs
+++ b/xsd-parser/tests/union/expected.rs
@@ -1,3 +1,4 @@
+#[allow(non_camel_case_types)]
 #[derive(PartialEq, Debug, UtilsUnionSerDe)]
 pub enum FooType {
     int(i32),

--- a/xsd-parser/tests/union/expected.rs
+++ b/xsd-parser/tests/union/expected.rs
@@ -1,7 +1,7 @@
 #[derive(PartialEq, Debug, UtilsUnionSerDe)]
 pub enum FooType {
-    Int(i32),
-    String(String),
+    int(i32),
+    string(String),
     __Unknown__(String),
 }
 

--- a/xsd-parser/tests/union/mod.rs
+++ b/xsd-parser/tests/union/mod.rs
@@ -13,7 +13,7 @@ fn deserialization_works() {
 
     let de: expected::FooType = yaserde::de::from_str(ser).unwrap();
 
-    assert_eq!(de, expected::FooType::String("string".to_string()));
+    assert_eq!(de, expected::FooType::string("string".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
As per #154, the current implementation pascalizes enum case names and can therefore cause clashes with valid XSDs.
I have replaced the default formatting for enum case names with just filtering and sanitization.

I also added an `#[allow(non_camel_case_types)]` to generated enums in order to avoid this change triggering clippy lints.