### PR TITLE
upgrade yaserde to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -38,47 +38,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -86,21 +87,21 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9324c8014cd04590682b34f1e9448d38f0674d0f7b2dc553331016ef0e4e9ebc"
+checksum = "8f850665a0385e070b64c38d2354e6c104c8479c59868d1e48a0c13ee2c7a1c1"
 dependencies = [
  "autocfg",
  "libm",
@@ -111,15 +112,18 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -129,9 +133,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -143,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -153,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -165,33 +169,33 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "getopts"
@@ -204,24 +208,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -241,10 +236,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.69"
+name = "is_terminal_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "js-sys"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -261,41 +262,40 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -311,42 +311,42 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "roxmltree"
@@ -378,27 +378,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
-name = "strsim"
-version = "0.11.0"
+name = "serde"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "serde_derive",
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.53"
+name = "serde_derive"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_tokenstream"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64060d864397305347a78851c51588fd283767e7e7589829e8121d65512340f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,58 +454,53 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -486,22 +508,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "winapi"
@@ -526,22 +548,23 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -550,45 +573,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wsdl-parser"
@@ -596,7 +625,7 @@ version = "0.1.0"
 dependencies = [
  "Inflector",
  "roxmltree",
- "syn 2.0.53",
+ "syn",
  "text-diff",
  "xsd-parser",
 ]
@@ -614,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.19"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
 
 [[package]]
 name = "xsd-macro-utils"
@@ -624,7 +653,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -634,13 +663,12 @@ dependencies = [
  "Inflector",
  "num-bigint",
  "roxmltree",
- "syn 2.0.53",
+ "syn",
  "text-diff",
  "xml-rs",
  "xsd-macro-utils",
  "xsd-types",
  "yaserde",
- "yaserde_derive",
 ]
 
 [[package]]
@@ -662,29 +690,31 @@ dependencies = [
  "xml-rs",
  "xsd-macro-utils",
  "yaserde",
- "yaserde_derive",
 ]
 
 [[package]]
 name = "yaserde"
-version = "0.7.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2776ec5bb20e76d89268e87e1ea66c078b94f55e9771e4d648adda3019f87fc"
+checksum = "8bfa0d2b420fd005aa9b6f99f9584ebd964e6865d7ca787304cc1a3366c39231"
 dependencies = [
  "log",
  "xml-rs",
+ "yaserde_derive",
 ]
 
 [[package]]
 name = "yaserde_derive"
-version = "0.7.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0b0a4701f203ebaecce4971a6bb8575aa07b617bdc39ddfc6ffeff3a38530d"
+checksum = "1f785831c0e09e0f1a83f917054fd59c088f6561db5b2a42c1c3e1687329325f"
 dependencies = [
- "heck 0.3.3",
+ "heck",
  "log",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "serde",
+ "serde_tokenstream",
+ "syn",
  "xml-rs",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,9 +373,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "roxmltree"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "serde"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In such cases we don't know in advance what fields must be present in Rust struc
 
 ```rust
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct MyType {
     #[yaserde(prefix = "tns", rename = "Parameters")]
     pub parameters: String,

--- a/wsdl-parser-cli/Cargo.toml
+++ b/wsdl-parser-cli/Cargo.toml
@@ -17,6 +17,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-roxmltree = { version = "0.19", features = ["std"] }
+roxmltree = { version = "0.20", features = ["std"] }
 wsdl-parser = { path = "../wsdl-parser" }
 xsd-parser = { path = "../xsd-parser" }

--- a/wsdl-parser/Cargo.toml
+++ b/wsdl-parser/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 Inflector = "0.11"
-roxmltree = "0.19"
+roxmltree = "0.20"
 
 [dev-dependencies]
 syn = { version = "2", features = ["full", "extra-traits"] }

--- a/wsdl-parser/tests/port_type_to_function/expected.rs
+++ b/wsdl-parser/tests/port_type_to_function/expected.rs
@@ -1,6 +1,6 @@
 
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tds", namespace = "tds: http://www.onvif.org/ver10/device/wsdl")]
+#[yaserde(prefix = "tds", namespaces = {"tds" = "http://www.onvif.org/ver10/device/wsdl"})]
 pub struct GetServices {
     // Indicates if the service capabilities (untyped) should be included in the
     // response.
@@ -12,7 +12,7 @@ impl Validate for GetServices {}
 
 
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tds", namespace = "tds: http://www.onvif.org/ver10/device/wsdl")]
+#[yaserde(prefix = "tds", namespaces = {"tds" = "http://www.onvif.org/ver10/device/wsdl"})]
 pub struct GetServicesResponse {
     // Each Service element contains information about one service.
     #[yaserde(prefix = "tds", rename = "Service")]

--- a/xsd-parser/Cargo.toml
+++ b/xsd-parser/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 Inflector = "0.11"
-roxmltree = "0.19"
+roxmltree = "0.20"
 
 [dev-dependencies]
 num-bigint = "0.4"

--- a/xsd-parser/Cargo.toml
+++ b/xsd-parser/Cargo.toml
@@ -21,5 +21,4 @@ text-diff = "0.4"
 xml-rs = "0.8"
 xsd-macro-utils = { path = "../xsd-macro-utils" }
 xsd-types = { path = "../xsd-types" }
-yaserde = "0.7"
-yaserde_derive = "0.7"
+yaserde = {version="0.12", features=["derive"]}

--- a/xsd-parser/src/generator/default.rs
+++ b/xsd-parser/src/generator/default.rs
@@ -67,13 +67,13 @@ pub fn default_modify_type(type_name: &str, modifiers: &[TypeModifier]) -> Cow<'
 pub fn yaserde_for_attribute(name: &str, indent: &str) -> String {
     if let Some(index) = name.find(':') {
         format!(
-            "{}#[yaserde(attribute, prefix = \"{}\", rename = \"{}\")]\n",
+            "{}#[yaserde(attribute = true, prefix = \"{}\", rename = \"{}\")]\n",
             indent,
             &name[0..index],
             &name[index + 1..]
         )
     } else {
-        format!("{}#[yaserde(attribute, rename = \"{}\")]\n", indent, name)
+        format!("{}#[yaserde(attribute = true, rename = \"{}\")]\n", indent, name)
     }
 }
 

--- a/xsd-parser/src/generator/enum.rs
+++ b/xsd-parser/src/generator/enum.rs
@@ -69,12 +69,15 @@ pub trait EnumGenerator {
         let tns = gen.target_ns.borrow();
         match tns.as_ref() {
             Some(tn) => match tn.name() {
+                // needs to put it differently when multiples namespaces are defined.
+                // namepsaces = {"tns" = "example.com", "tds = "another.example.com"}
                 Some(name) => format!(
-                    "{derives}#[yaserde(prefix = \"{prefix}\", namespace = \"{prefix}: {uri}\")]\n",
+                    "{derives}#[yaserde(prefix = \"{prefix}\", namespaces = {{\"{prefix}\" = \"{uri}\"}})]\n",
                     derives = derives,
                     prefix = name,
                     uri = tn.uri()
                 ),
+                // deal with it
                 None => format!(
                     "{derives}#[yaserde(namespace = \"{uri}\")]\n",
                     derives = derives,

--- a/xsd-parser/src/generator/struct.rs
+++ b/xsd-parser/src/generator/struct.rs
@@ -84,11 +84,12 @@ pub trait StructGenerator {
         match tns.as_ref() {
             Some(tn) => match tn.name() {
                 Some(name) => format!(
-                    "{derives}#[yaserde(prefix = \"{prefix}\", namespace = \"{prefix}: {uri}\")]\n",
+                    "{derives}#[yaserde(prefix = \"{prefix}\", namespaces = {{\"{prefix}\" = \"{uri}\"}})]\n",
                     derives = derives,
                     prefix = name,
                     uri = tn.uri()
                 ),
+                // todo: deal with it
                 None => format!(
                     "{derives}#[yaserde(namespace = \"{uri}\")]\n",
                     derives = derives,

--- a/xsd-parser/tests/all/expected.rs
+++ b/xsd-parser/tests/all/expected.rs
@@ -1,5 +1,5 @@
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct FooType {
     #[yaserde(prefix = "tns", rename = "Once")]
     pub once: i32,

--- a/xsd-parser/tests/all/mod.rs
+++ b/xsd-parser/tests/all/mod.rs
@@ -4,7 +4,7 @@ use super::utils;
 fn deserialization_works() {
     mod expected {
         use xsd_parser::generator::validator::Validate;
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-parser/tests/any/expected.rs
+++ b/xsd-parser/tests/any/expected.rs
@@ -1,5 +1,5 @@
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct FooType {
     #[yaserde(prefix = "tns", rename = "Name")]
     pub name: String,

--- a/xsd-parser/tests/any/mod.rs
+++ b/xsd-parser/tests/any/mod.rs
@@ -3,7 +3,7 @@ use super::utils;
 #[test]
 fn deserialization_works() {
     mod expected {
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-parser/tests/choice/expected.rs
+++ b/xsd-parser/tests/choice/expected.rs
@@ -5,7 +5,7 @@ pub struct BarType(pub String);
 pub struct BazType(pub i32);
 
 #[derive(PartialEq, Debug, Clone, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub enum FooTypeChoice {
     Bar(BarType),
     Baz(BazType),
@@ -19,8 +19,8 @@ impl Default for FooTypeChoice {
 }
 
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct FooType {
-    #[yaserde(flatten)]
+    #[yaserde(flatten = true)]
     pub foo_type_choice: FooTypeChoice,
 }

--- a/xsd-parser/tests/choice/mod.rs
+++ b/xsd-parser/tests/choice/mod.rs
@@ -6,7 +6,7 @@ fn deserialization_works() {
         use std::str::FromStr;
 
         use xsd_macro_utils::*;
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-parser/tests/complex_type/expected.rs
+++ b/xsd-parser/tests/complex_type/expected.rs
@@ -1,5 +1,5 @@
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct FooType {
     #[yaserde(prefix = "tns", rename = "Min")]
     pub min: i32,

--- a/xsd-parser/tests/complex_type/mod.rs
+++ b/xsd-parser/tests/complex_type/mod.rs
@@ -4,7 +4,7 @@ use super::utils;
 fn deserialization_works() {
     mod expected {
         use xsd_parser::generator::validator::Validate;
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-parser/tests/complex_type_subtypes_clash/expected.rs
+++ b/xsd-parser/tests/complex_type_subtypes_clash/expected.rs
@@ -1,5 +1,5 @@
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct FooType {
     #[yaserde(prefix = "tns", rename = "Extension")]
     pub extension: foo_type::ExtensionType,
@@ -11,14 +11,14 @@ pub mod foo_type {
     use super::*;
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+    #[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
     pub struct ExtensionType {}
 
     impl Validate for ExtensionType {}
 }
 
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct BarType {
     #[yaserde(prefix = "tns", rename = "Extension")]
     pub extension: bar_type::ExtensionType,
@@ -30,7 +30,7 @@ pub mod bar_type {
     use super::*;
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+    #[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
     pub struct ExtensionType {}
 
     impl Validate for ExtensionType {}

--- a/xsd-parser/tests/complex_type_subtypes_clash/mod.rs
+++ b/xsd-parser/tests/complex_type_subtypes_clash/mod.rs
@@ -4,7 +4,7 @@ use super::utils;
 fn deserialization_works() {
     mod expected {
         use xsd_parser::generator::validator::Validate;
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-parser/tests/enumeration/expected.rs
+++ b/xsd-parser/tests/enumeration/expected.rs
@@ -1,5 +1,5 @@
 #[derive(PartialEq, Debug, Clone, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub enum FooType {
     #[yaserde(rename = "OFF")]
     Off,

--- a/xsd-parser/tests/enumeration/mod.rs
+++ b/xsd-parser/tests/enumeration/mod.rs
@@ -7,7 +7,7 @@ fn deserialization_works() {
 
         use xsd_macro_utils::*;
         use xsd_parser::generator::validator::Validate;
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-parser/tests/extension_base/expected.rs
+++ b/xsd-parser/tests/extension_base/expected.rs
@@ -1,5 +1,5 @@
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct BarType {
     #[yaserde(prefix = "tns", rename = "b")]
     pub b: i32,
@@ -11,7 +11,7 @@ pub struct BarType {
 impl Validate for BarType {}
 
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct FooType {
     #[yaserde(prefix = "tns", rename = "a")]
     pub a: f64,

--- a/xsd-parser/tests/extension_base/mod.rs
+++ b/xsd-parser/tests/extension_base/mod.rs
@@ -4,7 +4,7 @@ use super::utils;
 fn deserialization_works() {
     mod expected {
         use xsd_parser::generator::validator::Validate;
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-parser/tests/extension_base_multilayer/expected.rs
+++ b/xsd-parser/tests/extension_base_multilayer/expected.rs
@@ -1,5 +1,5 @@
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct BarType {
     #[yaserde(prefix = "tns", rename = "aa")]
     pub aa: i32,
@@ -11,7 +11,7 @@ pub struct BarType {
 impl Validate for BarType {}
 
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct FooType {
     #[yaserde(prefix = "tns", rename = "Messages")]
     pub messages: foo_type::MessagesType,
@@ -23,7 +23,7 @@ pub mod foo_type {
     use super::*;
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+    #[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
     pub struct MessagesType {
         #[yaserde(prefix = "tns", rename = "a")]
         pub a: String,

--- a/xsd-parser/tests/extension_base_multilayer/mod.rs
+++ b/xsd-parser/tests/extension_base_multilayer/mod.rs
@@ -4,7 +4,7 @@ use super::utils;
 fn deserialization_works() {
     mod expected {
         use xsd_parser::generator::validator::Validate;
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-parser/tests/extension_base_two_files/expected.rs
+++ b/xsd-parser/tests/extension_base_two_files/expected.rs
@@ -1,8 +1,7 @@
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
     prefix = "tns",
-    namespace = "tns: http://example.com",
-    namespace = "tns2: http://other.example.com"
+    namespaces = {"tns" = "http://example.com", "tns2" = "http://other.example.com"},
 )]
 pub struct FooType {
     #[yaserde(prefix = "tns", rename = "a")]

--- a/xsd-parser/tests/extension_base_two_files/mod.rs
+++ b/xsd-parser/tests/extension_base_two_files/mod.rs
@@ -3,7 +3,7 @@ use super::utils;
 #[test]
 fn deserialization_works() {
     mod expected {
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
         include!("expected.rs");
     }
 

--- a/xsd-parser/tests/ref_to_attribute/expected.rs
+++ b/xsd-parser/tests/ref_to_attribute/expected.rs
@@ -3,9 +3,9 @@ pub struct Id(pub String);
 
 impl Validate for Id {}
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct FooType {
-    #[yaserde(attribute, prefix = "tns", rename = "id")]
+    #[yaserde(attribute = true, prefix = "tns", rename = "id")]
     pub id: Option<Id>,
 }
 

--- a/xsd-parser/tests/ref_to_attribute/mod.rs
+++ b/xsd-parser/tests/ref_to_attribute/mod.rs
@@ -7,7 +7,7 @@ fn deserialization_works() {
 
         use xsd_macro_utils::*;
         use xsd_parser::generator::validator::Validate;
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-parser/tests/rename_only_where_needed/expected.rs
+++ b/xsd-parser/tests/rename_only_where_needed/expected.rs
@@ -1,5 +1,5 @@
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct FooType {
     #[yaserde(prefix = "tns")]
     pub min: i32,

--- a/xsd-parser/tests/rename_only_where_needed/mod.rs
+++ b/xsd-parser/tests/rename_only_where_needed/mod.rs
@@ -3,7 +3,7 @@ use super::utils;
 #[test]
 fn deserialization_works() {
     mod expected {
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
         include!("expected.rs");
     }
 

--- a/xsd-parser/tests/restriction_any_type/expected.rs
+++ b/xsd-parser/tests/restriction_any_type/expected.rs
@@ -1,14 +1,14 @@
 // pub type AppSequence = AppSequenceType;
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://schemas.xmlsoap.org/ws/2005/04/discovery")]
+#[yaserde(prefix = "tns", namespaces = {"tns" =  "http://schemas.xmlsoap.org/ws/2005/04/discovery"})]
 pub struct AppSequenceType {
-    #[yaserde(attribute, rename = "InstanceId")]
+    #[yaserde(attribute = true, rename = "InstanceId")]
     pub instance_id: u32,
 
-    #[yaserde(attribute, rename = "SequenceId")]
+    #[yaserde(attribute = true, rename = "SequenceId")]
     pub sequence_id: Option<String>,
 
-    #[yaserde(attribute, rename = "MessageNumber")]
+    #[yaserde(attribute = true, rename = "MessageNumber")]
     pub message_number: u32,
 }
 

--- a/xsd-parser/tests/restriction_any_type/mod.rs
+++ b/xsd-parser/tests/restriction_any_type/mod.rs
@@ -4,7 +4,7 @@ use super::utils;
 fn deserialization_works() {
     mod expected {
         use xsd_parser::generator::validator::Validate;
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-parser/tests/tuple_with_vec/mod.rs
+++ b/xsd-parser/tests/tuple_with_vec/mod.rs
@@ -17,7 +17,7 @@ fn deserialization_works() {
     assert_eq!(de, expected::FooType(vec![1, 2, 3]));
 
     assert_eq!(
-        r#"<?xml version="1.0" encoding="utf-8"?><FooType>1 2 3</FooType>"#,
+        r#"<?xml version="1.0" encoding="UTF-8"?><FooType>1 2 3</FooType>"#,
         yaserde::ser::to_string(&de).unwrap()
     );
 }

--- a/xsd-parser/tests/type_name_clash/expected.rs
+++ b/xsd-parser/tests/type_name_clash/expected.rs
@@ -1,15 +1,14 @@
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct BarType {
-    #[yaserde(attribute, rename = "a")]
+    #[yaserde(attribute = true, rename = "a")]
     pub a: Option<String>,
 }
 
 impl Validate for BarType {}
 
-
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct FooType {
     #[yaserde(prefix = "tns", rename = "Bar")]
     pub bar: foo_type::BarType,
@@ -21,14 +20,13 @@ pub mod foo_type {
     use super::*;
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+    #[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
     pub struct BarType {
-        #[yaserde(attribute, rename = "b")]
+        #[yaserde(attribute = true, rename = "b")]
         pub b: Option<String>,
 
-        #[yaserde(attribute, rename = "a")]
+        #[yaserde(attribute = true, rename = "a")]
         pub a: Option<String>,
-
     }
 
     impl Validate for BarType {}

--- a/xsd-parser/tests/type_name_clash/mod.rs
+++ b/xsd-parser/tests/type_name_clash/mod.rs
@@ -4,7 +4,7 @@ use super::utils;
 fn deserialization_works() {
     mod expected {
         use xsd_parser::generator::validator::Validate;
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-parser/tests/xsd_string/expected.rs
+++ b/xsd-parser/tests/xsd_string/expected.rs
@@ -1,5 +1,5 @@
 #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
+#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
 pub struct FooType {
     #[yaserde(prefix = "tns", rename = "Text")]
     pub text: String,

--- a/xsd-parser/tests/xsd_string/mod.rs
+++ b/xsd-parser/tests/xsd_string/mod.rs
@@ -4,7 +4,7 @@ use super::utils;
 fn deserialization_works() {
     mod expected {
         use xsd_parser::generator::validator::Validate;
-        use yaserde_derive::{YaDeserialize, YaSerialize};
+        use yaserde::{YaDeserialize, YaSerialize};
 
         include!("expected.rs");
     }

--- a/xsd-types/Cargo.toml
+++ b/xsd-types/Cargo.toml
@@ -16,7 +16,7 @@ chrono = "0.4"
 num-bigint = "0.4"
 xml-rs = "0.8"
 xsd-macro-utils = { path = "../xsd-macro-utils" }
-yaserde = "0.7"
+yaserde = "0.12"
 
 [dev-dependencies]
-yaserde_derive = "0.7"
+yaserde = {version="0.12", features=["derive"]}

--- a/xsd-types/src/types/date.rs
+++ b/xsd-types/src/types/date.rs
@@ -82,7 +82,7 @@ impl fmt::Display for Date {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -164,7 +164,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct Message {
         #[yaserde(prefix = "t", rename = "CreatedAt")]
         pub created_at: Date,
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn date_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>2020-02-02+06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn date_deserialize_test() {
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>2020-02-02-06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>

--- a/xsd-types/src/types/datetime.rs
+++ b/xsd-types/src/types/datetime.rs
@@ -51,7 +51,7 @@ impl fmt::Display for DateTime {
 #[cfg(test)]
 mod tests {
     use chrono::NaiveDate;
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -107,7 +107,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct Message {
         #[yaserde(prefix = "t", rename = "CreatedAt")]
         pub created_at: DateTime,
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn datetime_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>2020-03-07T04:40:00+06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn datetime_deserialize_test() {
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>2020-03-07T04:40:00-06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>

--- a/xsd-types/src/types/datetimestamp.rs
+++ b/xsd-types/src/types/datetimestamp.rs
@@ -41,7 +41,7 @@ impl fmt::Display for DateTimeStamp {
 #[cfg(test)]
 mod tests {
     use chrono::NaiveDate;
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -115,7 +115,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct Message {
         #[yaserde(prefix = "t", rename = "CreatedAt")]
         pub created_at: DateTimeStamp,
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn datetime_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>2020-03-07T04:40:00+06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn datetime_deserialize_test() {
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>2020-03-07T04:40:00-06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>

--- a/xsd-types/src/types/decimal.rs
+++ b/xsd-types/src/types/decimal.rs
@@ -33,13 +33,13 @@ impl fmt::Display for Decimal {
 #[cfg(test)]
 mod tests {
     use num_bigint::ToBigInt;
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct DecimalPair {
         #[yaserde(prefix = "t", rename = "First")]
         pub first: Decimal,
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn integer_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:DecimalPair xmlns:t="test">
                 <t:First>0.01234</t:First>
                 <t:Second>-12.34</t:Second>
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn integer_deserialize_test() {
         // Value "+0.01234" is used to check optional plus sign deserialization.
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:DecimalPair xmlns:t="test">
                 <t:First>+0.01234</t:First>
                 <t:Second>-12.34</t:Second>

--- a/xsd-types/src/types/gday.rs
+++ b/xsd-types/src/types/gday.rs
@@ -78,7 +78,7 @@ impl fmt::Display for GDay {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -149,7 +149,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct Message {
         #[yaserde(prefix = "t", rename = "CreatedAt")]
         pub created_at: GDay,
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn gday_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>---07+06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn gday_deserialize_test() {
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>---29-06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>

--- a/xsd-types/src/types/gmonth.rs
+++ b/xsd-types/src/types/gmonth.rs
@@ -78,7 +78,7 @@ impl fmt::Display for GMonth {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -149,7 +149,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct Message {
         #[yaserde(prefix = "t", rename = "CreatedAt")]
         pub created_at: GMonth,
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn gmonth_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>--07+06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn gmonth_deserialize_test() {
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>--09-06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>

--- a/xsd-types/src/types/gmonthday.rs
+++ b/xsd-types/src/types/gmonthday.rs
@@ -110,7 +110,7 @@ impl fmt::Display for GMonthDay {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -200,7 +200,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct Message {
         #[yaserde(prefix = "t", rename = "CreatedAt")]
         pub created_at: GMonthDay,
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn gmonthday_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>--07-09+06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>
@@ -231,7 +231,7 @@ mod tests {
 
     #[test]
     fn gmonthday_deserialize_test() {
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>--07-09-06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>

--- a/xsd-types/src/types/gyear.rs
+++ b/xsd-types/src/types/gyear.rs
@@ -97,7 +97,7 @@ impl fmt::Display for GYear {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -209,7 +209,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct Message {
         #[yaserde(prefix = "t", rename = "CreatedAt")]
         pub created_at: GYear,
@@ -220,7 +220,7 @@ mod tests {
 
     #[test]
     fn gyear_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>2007+06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn gyear_deserialize_test() {
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>2007-06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>

--- a/xsd-types/src/types/gyearmonth.rs
+++ b/xsd-types/src/types/gyearmonth.rs
@@ -126,7 +126,7 @@ impl fmt::Display for GYearMonth {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -259,7 +259,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t"= "test"})]
     pub struct Message {
         #[yaserde(prefix = "t", rename = "CreatedAt")]
         pub created_at: GYearMonth,
@@ -270,7 +270,7 @@ mod tests {
 
     #[test]
     fn gyearmonth_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>2007-02+06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn gyearmonth_deserialize_test() {
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>2007-02-06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>

--- a/xsd-types/src/types/integer.rs
+++ b/xsd-types/src/types/integer.rs
@@ -35,7 +35,7 @@ impl fmt::Display for Integer {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -75,7 +75,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct IntegerPair {
         #[yaserde(prefix = "t", rename = "First")]
         pub first: Integer,
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn integer_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:IntegerPair xmlns:t="test">
                 <t:First>1234</t:First>
                 <t:Second>-1234</t:Second>
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn integer_deserialize_test() {
         // Value "+1234" is used to check optional plus sign deserialization.
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:IntegerPair xmlns:t="test">
                 <t:First>+1234</t:First>
                 <t:Second>-1234</t:Second>

--- a/xsd-types/src/types/negative_integer.rs
+++ b/xsd-types/src/types/negative_integer.rs
@@ -40,7 +40,7 @@ impl fmt::Display for NegativeInteger {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -84,7 +84,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct NegativeIntegerPair {
         #[yaserde(prefix = "t", rename = "First")]
         pub first: NegativeInteger,
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn negative_integer_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:NegativeIntegerPair xmlns:t="test">
                 <t:First>-1</t:First>
                 <t:Second>-1234</t:Second>
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn negative_integer_deserialize_test() {
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:NegativeIntegerPair xmlns:t="test">
                 <t:First>-1</t:First>
                 <t:Second>-1234</t:Second>

--- a/xsd-types/src/types/non_negative_integer.rs
+++ b/xsd-types/src/types/non_negative_integer.rs
@@ -40,7 +40,7 @@ impl fmt::Display for NonNegativeInteger {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -84,7 +84,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct NonNegativeIntegerPair {
         #[yaserde(prefix = "t", rename = "First")]
         pub first: NonNegativeInteger,
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn non_negative_integer_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:NonNegativeIntegerPair xmlns:t="test">
                 <t:First>1234</t:First>
                 <t:Second>0</t:Second>
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn non_negative_integer_deserialize_test() {
         // Value "+1234" is used to check optional plus sign deserialization.
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:NonNegativeIntegerPair xmlns:t="test">
                 <t:First>+1234</t:First>
                 <t:Second>0</t:Second>

--- a/xsd-types/src/types/non_positive_integer.rs
+++ b/xsd-types/src/types/non_positive_integer.rs
@@ -40,7 +40,7 @@ impl fmt::Display for NonPositiveInteger {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -91,7 +91,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct NonPositiveIntegerPair {
         #[yaserde(prefix = "t", rename = "First")]
         pub first: NonPositiveInteger,
@@ -102,7 +102,7 @@ mod tests {
 
     #[test]
     fn non_positive_integer_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:NonPositiveIntegerPair xmlns:t="test">
                 <t:First>0</t:First>
                 <t:Second>-1234</t:Second>
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn non_positive_integer_deserialize_test() {
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:NonPositiveIntegerPair xmlns:t="test">
                 <t:First>0</t:First>
                 <t:Second>-1234</t:Second>

--- a/xsd-types/src/types/positive_integer.rs
+++ b/xsd-types/src/types/positive_integer.rs
@@ -40,7 +40,7 @@ impl fmt::Display for PositiveInteger {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -80,7 +80,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct PositiveIntegerPair {
         #[yaserde(prefix = "t", rename = "First")]
         pub first: PositiveInteger,
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn positive_integer_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:PositiveIntegerPair xmlns:t="test">
                 <t:First>1234</t:First>
                 <t:Second>1</t:Second>
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     fn positive_integer_deserialize_test() {
         // Value "+1234" is used to check optional plus sign deserialization.
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:PositiveIntegerPair xmlns:t="test">
                 <t:First>+1234</t:First>
                 <t:Second>1</t:Second>

--- a/xsd-types/src/types/time.rs
+++ b/xsd-types/src/types/time.rs
@@ -86,7 +86,7 @@ impl fmt::Display for Time {
 
 #[cfg(test)]
 mod tests {
-    use yaserde_derive::{YaDeserialize, YaSerialize};
+    use yaserde::{YaDeserialize, YaSerialize};
 
     use super::*;
     use crate::utils::xml_eq::assert_xml_eq;
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
-    #[yaserde(prefix = "t", namespace = "t: test")]
+    #[yaserde(prefix = "t", namespaces = {"t" = "test"})]
     pub struct Message {
         #[yaserde(prefix = "t", rename = "CreatedAt")]
         pub created_at: Time,
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn datetime_serialize_test() {
-        let expected = r#"<?xml version="1.0" encoding="utf-8"?>
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>04:40:00+06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn integer_deserialize_test() {
-        let s = r#"<?xml version="1.0" encoding="utf-8"?>
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
             <t:Message xmlns:t="test">
                 <t:CreatedAt>04:40:00-06:30</t:CreatedAt>
                 <t:Text>Hello world</t:Text>


### PR DESCRIPTION
**Do not merge yet**
Three breaking changes:

parameter `namespace` is now `namespaces` and can include multiple namespace.
```
#[yaserde(prefix = "tns", namespace = "tns: http://example.com")]
#[yaserde(prefix = "tns", namespaces = {"tns" = "http://example.com"})]
```

This PR needs to be edited to take into account that multiples namespace must be included in one parameter.
Using this PR at the current state with multiple definition of namespace will generate incorrect code.

field `attribute` needs to have a boolean value instead of just being present.
```
    #[yaserde(attribute, prefix = "tns", rename = "id")]
    #[yaserde(attribute = true, prefix = "tns", rename = "id")]
```

name of encoding is now UTF-8 instead of utf-8.
```
        let s = r#"<?xml version="1.0" encoding="utf-8"?>
        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
```